### PR TITLE
feat: ヘッダーのPodQueueのPをアイコン画像に置き換え

### DIFF
--- a/app/podcasts/page.tsx
+++ b/app/podcasts/page.tsx
@@ -20,9 +20,9 @@ export default async function PodcastsPage() {
 		<div className="min-h-screen bg-background">
 			<header className="border-b">
 				<div className="container mx-auto px-4 py-4 flex items-center justify-between">
-					<div className="flex items-center gap-2">
-						<Image src="/podqueue-icon.svg" alt="PodQueue" width={32} height={32} />
-						<h1 className="text-2xl font-bold">PodQueue</h1>
+					<div className="flex items-center gap-0">
+						<Image src="/podqueue-icon.svg" alt="P" width={32} height={32} />
+						<h1 className="text-2xl font-bold">odQueue</h1>
 					</div>
 					<div className="flex items-center gap-4">
 						<Link href="/podcasts/add">


### PR DESCRIPTION
## Summary

ヘッダーのPodQueueのPをアイコン画像に置き換えてスペースを削減しました。

- テキストを「PodQueue」から「odQueue」に変更
- アイコンとテキストの間隔を`gap-0`に変更して一体感を出す

Closes #13

Generated with [Claude Code](https://claude.ai/code)