### PR TITLE
feat: Podcast追加フォームをモーダル方式に変更

### DIFF
--- a/app/podcasts/page.tsx
+++ b/app/podcasts/page.tsx
@@ -1,9 +1,9 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { PodcastList } from "@/components/podcast-list";
+import { AddPodcastDialog } from "@/components/add-podcast-dialog";
 import { Button } from "@/components/ui/button";
-import { LogOut, PlusCircle } from "lucide-react";
-import Link from "next/link";
+import { LogOut } from "lucide-react";
 import Image from "next/image";
 
 export default async function PodcastsPage() {
@@ -25,12 +25,7 @@ export default async function PodcastsPage() {
 						<h1 className="text-2xl font-bold">PodQueue</h1>
 					</div>
 					<div className="flex items-center gap-4">
-						<Link href="/podcasts/add">
-							<Button>
-								<PlusCircle className="size-4" />
-								<span className="hidden sm:inline">Podcastを追加</span>
-							</Button>
-						</Link>
+						<AddPodcastDialog userId={user.id} />
 						<form
 							action={async () => {
 								"use server";


### PR DESCRIPTION
## Summary

- 「Podcastを追加」ボタンのフォーム表示遅延を改善
- ページ遷移方式からダイアログ方式に変更
- 即座にフォームが表示されるようになります

## Test plan

- [ ] 「Podcastを追加」ボタンクリックでダイアログが即座に開く
- [ ] フォームに入力してPodcastを追加できる
- [ ] メタデータ取得ボタンが正常に動作する
- [ ] キャンセルボタンでダイアログが閉じる
- [ ] ダイアログ外をクリックして閉じられる

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/code)