### PR TITLE
feat: ブランドカラーでアクセントをつける

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -39,10 +39,15 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10 bg-gradient-to-br from-purple-50 to-blue-50">
       <div className="w-full max-w-sm">
-        <Card>
-          <CardHeader>
+        <Card className="border-t-4 border-t-primary shadow-lg">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-blue-500">
+              <svg className="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15.536a5 5 0 001.414 1.414m2.828-9.9a9 9 0 0112.728 0" />
+              </svg>
+            </div>
             <CardTitle className="text-2xl">ログイン</CardTitle>
             <CardDescription>メールアドレスとパスワードを入力してログインしてください</CardDescription>
           </CardHeader>
@@ -77,7 +82,7 @@ export default function LoginPage() {
               </div>
               <div className="mt-4 text-center text-sm">
                 アカウントをお持ちでない方は{" "}
-                <Link href="/auth/sign-up" className="underline underline-offset-4">
+                <Link href="/auth/sign-up" className="text-primary hover:text-primary/80 underline underline-offset-4">
                   新規登録
                 </Link>
               </div>

--- a/app/auth/sign-up-success/page.tsx
+++ b/app/auth/sign-up-success/page.tsx
@@ -4,14 +4,14 @@ import Link from "next/link"
 
 export default function SignUpSuccessPage() {
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10 bg-gradient-to-br from-purple-50 to-blue-50">
       <div className="w-full max-w-sm">
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <CheckCircle className="size-6 text-green-600" />
-              <CardTitle className="text-2xl">登録完了</CardTitle>
+        <Card className="border-t-4 border-t-primary shadow-lg">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-green-100">
+              <CheckCircle className="size-8 text-green-600" />
             </div>
+            <CardTitle className="text-2xl">登録完了</CardTitle>
             <CardDescription>確認メールを送信しました</CardDescription>
           </CardHeader>
           <CardContent>
@@ -19,7 +19,7 @@ export default function SignUpSuccessPage() {
               ご登録いただいたメールアドレスに確認メールを送信しました。
               メール内のリンクをクリックして、アカウントを有効化してください。
             </p>
-            <Link href="/auth/login" className="text-sm underline underline-offset-4">
+            <Link href="/auth/login" className="text-sm text-primary hover:text-primary/80 underline underline-offset-4">
               ログインページに戻る
             </Link>
           </CardContent>

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -48,10 +48,15 @@ export default function SignUpPage() {
   }
 
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10 bg-gradient-to-br from-purple-50 to-blue-50">
       <div className="w-full max-w-sm">
-        <Card>
-          <CardHeader>
+        <Card className="border-t-4 border-t-primary shadow-lg">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-blue-500">
+              <svg className="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+              </svg>
+            </div>
             <CardTitle className="text-2xl">新規登録</CardTitle>
             <CardDescription>新しいアカウントを作成します</CardDescription>
           </CardHeader>
@@ -96,7 +101,7 @@ export default function SignUpPage() {
               </div>
               <div className="mt-4 text-center text-sm">
                 既にアカウントをお持ちの方は{" "}
-                <Link href="/auth/login" className="underline underline-offset-4">
+                <Link href="/auth/login" className="text-primary hover:text-primary/80 underline underline-offset-4">
                   ログイン
                 </Link>
               </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,24 +5,24 @@
 
 :root {
   --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --foreground: oklch(0.30 0 0);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.30 0 0);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.30 0 0);
+  --primary: oklch(0.585 0.233 292);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.97 0.005 292);
+  --secondary-foreground: oklch(0.30 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --muted-foreground: oklch(0.50 0 0);
+  --accent: oklch(0.585 0.233 292);
+  --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --input: oklch(0.922 0.010 292);
+  --ring: oklch(0.585 0.233 292);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -30,48 +30,53 @@
   --chart-5: oklch(0.769 0.188 70.08);
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.30 0 0);
+  --sidebar-primary: oklch(0.585 0.233 292);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-accent: oklch(0.95 0.010 292);
+  --sidebar-accent-foreground: oklch(0.30 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-ring: oklch(0.585 0.233 292);
+
+  /* Brand colors from logo gradient */
+  --brand-purple: oklch(0.585 0.233 292);
+  --brand-blue: oklch(0.595 0.195 255);
+  --brand-gradient: linear-gradient(135deg, var(--brand-purple), var(--brand-blue));
 }
 
 .dark {
   --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
+  --foreground: oklch(0.90 0 0);
   --card: oklch(0.145 0 0);
-  --card-foreground: oklch(0.985 0 0);
+  --card-foreground: oklch(0.90 0 0);
   --popover: oklch(0.145 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
+  --popover-foreground: oklch(0.90 0 0);
+  --primary: oklch(0.65 0.20 292);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.269 0.02 292);
+  --secondary-foreground: oklch(0.90 0 0);
   --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.65 0 0);
+  --accent: oklch(0.65 0.20 292);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
   --destructive-foreground: oklch(0.637 0.237 25.331);
   --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
+  --input: oklch(0.269 0.02 292);
+  --ring: oklch(0.65 0.20 292);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-foreground: oklch(0.90 0 0);
+  --sidebar-primary: oklch(0.65 0.20 292);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.30 0.03 292);
+  --sidebar-accent-foreground: oklch(0.90 0 0);
   --sidebar-border: oklch(0.269 0 0);
-  --sidebar-ring: oklch(0.439 0 0);
+  --sidebar-ring: oklch(0.65 0.20 292);
 }
 
 @theme inline {

--- a/components/add-podcast-form.tsx
+++ b/components/add-podcast-form.tsx
@@ -136,9 +136,9 @@ export function AddPodcastForm({ userId, onSuccess }: AddPodcastFormProps) {
 	};
 
 	return (
-		<Card>
+		<Card className="border-t-4 border-t-primary">
 			<CardHeader>
-				<CardTitle>新しいPodcastを追加</CardTitle>
+				<CardTitle className="bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">新しいPodcastを追加</CardTitle>
 				<CardDescription>PodcastのURLを入力して、自動的にメタデータを取得できます</CardDescription>
 			</CardHeader>
 			<CardContent>

--- a/components/podcast-card.tsx
+++ b/components/podcast-card.tsx
@@ -47,7 +47,7 @@ export function PodcastCard({ podcast, onToggleWatched, onDelete }: PodcastCardP
 
   return (
     <>
-      <Card className="flex flex-col h-full cursor-pointer hover:shadow-lg transition-shadow gap-0" onClick={() => setIsDialogOpen(true)}>
+      <Card className="flex flex-col h-full cursor-pointer hover:shadow-lg hover:border-primary/30 transition-all gap-0" onClick={() => setIsDialogOpen(true)}>
         <CardHeader className="p-0 relative">
           {podcast.thumbnail_url ? (
             <div className="relative w-full aspect-video">

--- a/components/podcast-dialog.tsx
+++ b/components/podcast-dialog.tsx
@@ -61,8 +61,8 @@ export function PodcastDialog({ podcast, open, onOpenChange, onToggleWatched, on
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="text-xl pr-6">{podcast.title || "タイトルなし"}</DialogTitle>
+        <DialogHeader className="border-b pb-4">
+          <DialogTitle className="text-xl pr-6 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">{podcast.title || "タイトルなし"}</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
           {podcast.thumbnail_url && (

--- a/components/podcast-list-item.tsx
+++ b/components/podcast-list-item.tsx
@@ -58,7 +58,7 @@ export function PodcastListItem({ podcast, onToggleWatched, onDelete }: PodcastL
   return (
     <>
       <div
-        className="flex gap-3 p-3 sm:p-4 border rounded-lg cursor-pointer hover:shadow-md transition-shadow bg-card"
+        className="flex gap-3 p-3 sm:p-4 border rounded-lg cursor-pointer hover:shadow-md hover:border-primary/30 transition-all bg-card"
         role="button"
         tabIndex={0}
         onClick={handleClick}

--- a/components/podcasts-header.tsx
+++ b/components/podcasts-header.tsx
@@ -24,11 +24,11 @@ export function PodcastsHeader({ userId }: PodcastsHeaderProps) {
 	};
 
 	return (
-		<header className="border-b">
+		<header className="border-b bg-gradient-to-r from-purple-50/50 to-blue-50/50">
 			<div className="container mx-auto px-4 py-4 flex items-center justify-between">
 				<div className="flex items-center gap-2">
 					<Image src="/podqueue-icon.svg" alt="PodQueue" width={32} height={32} />
-					<h1 className="text-2xl font-bold">PodQueue</h1>
+					<h1 className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">PodQueue</h1>
 				</div>
 				<div className="flex items-center gap-4">
 					<Button onClick={() => setOpen(true)}>
@@ -44,8 +44,8 @@ export function PodcastsHeader({ userId }: PodcastsHeaderProps) {
 
 			<Dialog open={open} onOpenChange={setOpen}>
 				<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-					<DialogHeader>
-						<DialogTitle>Podcastを追加</DialogTitle>
+					<DialogHeader className="border-b pb-4">
+						<DialogTitle className="bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">Podcastを追加</DialogTitle>
 						<DialogDescription>PodcastのURLを入力して追加できます</DialogDescription>
 					</DialogHeader>
 					<AddPodcastForm userId={userId} onSuccess={() => setOpen(false)} />


### PR DESCRIPTION
Closes #25

## 変更内容

アイコン画像のグラデーション（紫〜青）をブランドカラーとして設定し、各コンポーネントにアクセントカラーを適用しました。

- CSS変数にブランドカラーを追加
- テキストカラーをグレー寄りに調整
- ログイン画面にグラデーション背景を適用
- ヘッダーにアクセントカラーを適用
- カード、モーダルにアクセントカラーを適用

Generated with [Claude Code](https://claude.ai/code)