### PR TITLE
feat: 視聴済み日時(watched_at)を管理するカラムを追加

### DIFF
--- a/components/podcast-card.tsx
+++ b/components/podcast-card.tsx
@@ -24,6 +24,7 @@ type Podcast = {
   thumbnail_url: string | null
   platform: string | null
   is_watched: boolean
+  watched_at: string | null
 }
 
 type PodcastCardProps = {

--- a/components/podcast-dialog.tsx
+++ b/components/podcast-dialog.tsx
@@ -16,6 +16,7 @@ type Podcast = {
   thumbnail_url: string | null
   platform: string | null
   is_watched: boolean
+  watched_at: string | null
 }
 
 type PodcastDialogProps = {

--- a/components/podcast-list-item.tsx
+++ b/components/podcast-list-item.tsx
@@ -23,6 +23,7 @@ type Podcast = {
   thumbnail_url: string | null
   platform: string | null
   is_watched: boolean
+  watched_at: string | null
 }
 
 type PodcastListItemProps = {

--- a/components/podcast-list.tsx
+++ b/components/podcast-list.tsx
@@ -15,6 +15,7 @@ type Podcast = {
 	thumbnail_url: string | null;
 	platform: string | null;
 	is_watched: boolean;
+	watched_at: string | null;
 	created_at: string;
 };
 
@@ -76,13 +77,15 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
 
 	const handleToggleWatched = async (id: string, currentStatus: boolean) => {
 		const supabase = createClient();
+		const newStatus = !currentStatus;
+		const watched_at = newStatus ? new Date().toISOString() : null;
 
-		const { error } = await supabase.from("podcasts").update({ is_watched: !currentStatus }).eq("id", id);
+		const { error } = await supabase.from("podcasts").update({ is_watched: newStatus, watched_at }).eq("id", id);
 
 		if (error) {
 			console.error("[v0] ステータス更新エラー:", error);
 		} else {
-			setPodcasts((prev) => prev.map((p) => (p.id === id ? { ...p, is_watched: !currentStatus } : p)));
+			setPodcasts((prev) => prev.map((p) => (p.id === id ? { ...p, is_watched: newStatus, watched_at } : p)));
 		}
 	};
 

--- a/scripts/002_add_watched_at.sql
+++ b/scripts/002_add_watched_at.sql
@@ -1,0 +1,10 @@
+-- watched_atカラムを追加
+alter table public.podcasts add column if not exists watched_at timestamp with time zone;
+
+-- インデックスを作成
+create index if not exists podcasts_watched_at_idx on public.podcasts(watched_at desc);
+
+-- 既存のis_watched=trueのレコードにwatched_atを設定（updated_atを使用）
+update public.podcasts
+set watched_at = updated_at
+where is_watched = true and watched_at is null;


### PR DESCRIPTION
- データベースにwatched_atカラムを追加するマイグレーションファイルを作成
- Podcast型定義にwatched_atフィールドを追加
- 視聴済み/未視聴の切り替え時にwatched_atも更新するように修正
  - 視聴済みにする: 現在日時を設定
  - 未視聴にする: nullを設定