### PR TITLE
feat: テレ東Biz対応を追加

### DIFF
--- a/components/add-podcast-form.tsx
+++ b/components/add-podcast-form.tsx
@@ -33,6 +33,7 @@ export function AddPodcastForm({ userId, onSuccess }: AddPodcastFormProps) {
 		if (url.includes("spotify.com")) return "Spotify";
 		if (url.includes("newspicks.com") || url.includes("npx.me")) return "NewsPicks";
 		if (url.includes("pivot")) return "Pivot";
+		if (url.includes("txbiz.tv-tokyo.co.jp")) return "テレ東Biz";
 		return "その他";
 	};
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,5 +12,6 @@ export function getPlatformColor(platform: string | null): string {
   if (platformLower.includes("spotify")) return "bg-green-500"
   if (platformLower.includes("newspicks")) return "bg-blue-500"
   if (platformLower.includes("pivot")) return "bg-purple-500"
+  if (platformLower.includes("テレ東biz")) return "bg-red-600"
   return "bg-gray-500"
 }


### PR DESCRIPTION
## Summary
- `txbiz.tv-tokyo.co.jp` を含むURLを「テレ東Biz」として自動検出
- テレ東Biz用に赤系統色（`bg-red-600`）を設定

Closes #36

Generated with [Claude Code](https://claude.ai/code)