### PR TITLE
fix: スマホ画面で長いタイトルが見切れる問題を修正

### DIFF
--- a/components/podcast-dialog.tsx
+++ b/components/podcast-dialog.tsx
@@ -71,7 +71,7 @@ export function PodcastDialog({ podcast, open, onOpenChange, onToggleWatched, on
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader className="border-b pb-4">
-          <DialogTitle className="text-xl pr-6 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">{podcast.title || "タイトルなし"}</DialogTitle>
+          <DialogTitle className="text-xl pr-8 line-clamp-3 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">{podcast.title || "タイトルなし"}</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
           {podcast.thumbnail_url && (


### PR DESCRIPTION
## Summary

DialogTitleにline-clamp-3を適用して、長いタイトルを最大3行に制限しました。

Closes #42

Generated with [Claude Code](https://claude.ai/code)