### PR TITLE
fix: Newspicksのバッジ色を黒に変更

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,7 +10,7 @@ export function getPlatformColor(platform: string | null): string {
   const platformLower = platform.toLowerCase()
   if (platformLower.includes("youtube")) return "bg-red-500"
   if (platformLower.includes("spotify")) return "bg-green-500"
-  if (platformLower.includes("newspicks")) return "bg-blue-500"
+  if (platformLower.includes("newspicks")) return "bg-black"
   if (platformLower.includes("pivot")) return "bg-purple-500"
   if (platformLower.includes("テレ東biz")) return "bg-red-600"
   return "bg-gray-500"


### PR DESCRIPTION
## Summary
- Newspicksのバッジの背景色を青（bg-blue-500）から黒（bg-black）に変更
- Newspicksのロゴが黒なので、バッジ色を合わせました

Closes #71

🤖 Generated with [Claude Code](https://claude.ai/code)