### PR TITLE
feat: サンプルPodcast URLを公開する機能を追加

### DIFF
--- a/app/samples/[id]/page.tsx
+++ b/app/samples/[id]/page.tsx
@@ -1,0 +1,87 @@
+import { getSamplePodcast, getAllSampleIds } from "@/lib/samples/data";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Image from "next/image";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+// 静的生成のためのパラメータを生成
+export async function generateStaticParams() {
+  return getAllSampleIds().map((id) => ({
+    id,
+  }));
+}
+
+// OGPメタデータを動的に生成
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const podcast = getSamplePodcast(id);
+
+  if (!podcast) {
+    return {
+      title: "Not Found",
+    };
+  }
+
+  // 本番環境のURLを構築
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://podcast-queue.vercel.app";
+  const thumbnailUrl = `${baseUrl}${podcast.thumbnailPath}`;
+
+  return {
+    title: podcast.title,
+    description: podcast.description,
+    openGraph: {
+      title: podcast.title,
+      description: podcast.description,
+      images: [
+        {
+          url: thumbnailUrl,
+          width: 1200,
+          height: 630,
+          alt: podcast.title,
+        },
+      ],
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: podcast.title,
+      description: podcast.description,
+      images: [thumbnailUrl],
+    },
+  };
+}
+
+export default async function SamplePodcastPage({ params }: PageProps) {
+  const { id } = await params;
+  const podcast = getSamplePodcast(id);
+
+  if (!podcast) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-8">
+      <div className="max-w-2xl w-full space-y-6">
+        <div className="relative aspect-video w-full overflow-hidden rounded-lg">
+          <Image
+            src={podcast.thumbnailPath}
+            alt={podcast.title}
+            fill
+            className="object-cover"
+            priority
+          />
+        </div>
+        <h1 className="text-2xl font-bold">{podcast.title}</h1>
+        <p className="text-muted-foreground">{podcast.description}</p>
+        <div className="pt-4 border-t">
+          <p className="text-sm text-muted-foreground">
+            これはPodQueueのデモ用サンプルページです。
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/samples/data.ts
+++ b/lib/samples/data.ts
@@ -1,0 +1,43 @@
+/**
+ * サンプルPodcastデータ
+ * デモや説明画像用に使用するダミーデータ
+ */
+
+export interface SamplePodcast {
+  id: string;
+  title: string;
+  description: string;
+  thumbnailPath: string;
+}
+
+export const samplePodcasts: SamplePodcast[] = [
+  {
+    id: "podcast-1",
+    title: "テクノロジーの未来 - AI革命の最前線",
+    description:
+      "人工知能がもたらす変革について、業界の専門家が深掘りする番組。最新のAI技術から社会への影響まで、幅広いトピックを分かりやすく解説します。",
+    thumbnailPath: "/samples/podcast-1.svg",
+  },
+  {
+    id: "podcast-2",
+    title: "スタートアップ成功の秘訣",
+    description:
+      "起業家へのインタビューを通じて、成功への道のりを探る番組。失敗談から学ぶ教訓、資金調達のコツ、チームビルディングなど、実践的なアドバイスをお届けします。",
+    thumbnailPath: "/samples/podcast-2.svg",
+  },
+  {
+    id: "podcast-3",
+    title: "日々のマインドフルネス習慣",
+    description:
+      "忙しい現代人のための瞑想とマインドフルネスのガイド。10分間の簡単なエクササイズから、ストレス管理のテクニックまで、心の健康を保つためのヒントを紹介。",
+    thumbnailPath: "/samples/podcast-3.svg",
+  },
+];
+
+export function getSamplePodcast(id: string): SamplePodcast | undefined {
+  return samplePodcasts.find((podcast) => podcast.id === id);
+}
+
+export function getAllSampleIds(): string[] {
+  return samplePodcasts.map((podcast) => podcast.id);
+}

--- a/public/samples/podcast-1.svg
+++ b/public/samples/podcast-1.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg1)"/>
+  <circle cx="600" cy="280" r="120" fill="rgba(255,255,255,0.2)"/>
+  <polygon points="560,220 560,340 680,280" fill="white"/>
+  <text x="600" y="480" font-family="system-ui, sans-serif" font-size="48" font-weight="bold" fill="white" text-anchor="middle">テクノロジーの未来</text>
+  <text x="600" y="540" font-family="system-ui, sans-serif" font-size="28" fill="rgba(255,255,255,0.8)" text-anchor="middle">AI革命の最前線</text>
+</svg>

--- a/public/samples/podcast-2.svg
+++ b/public/samples/podcast-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f093fb;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#f5576c;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg2)"/>
+  <circle cx="600" cy="280" r="120" fill="rgba(255,255,255,0.2)"/>
+  <polygon points="560,220 560,340 680,280" fill="white"/>
+  <text x="600" y="480" font-family="system-ui, sans-serif" font-size="48" font-weight="bold" fill="white" text-anchor="middle">スタートアップ成功の秘訣</text>
+  <text x="600" y="540" font-family="system-ui, sans-serif" font-size="28" fill="rgba(255,255,255,0.8)" text-anchor="middle">起業家インタビュー</text>
+</svg>

--- a/public/samples/podcast-3.svg
+++ b/public/samples/podcast-3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4facfe;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#00f2fe;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg3)"/>
+  <circle cx="600" cy="280" r="120" fill="rgba(255,255,255,0.2)"/>
+  <polygon points="560,220 560,340 680,280" fill="white"/>
+  <text x="600" y="480" font-family="system-ui, sans-serif" font-size="48" font-weight="bold" fill="white" text-anchor="middle">日々のマインドフルネス習慣</text>
+  <text x="600" y="540" font-family="system-ui, sans-serif" font-size="28" fill="rgba(255,255,255,0.8)" text-anchor="middle">瞑想とストレス管理</text>
+</svg>


### PR DESCRIPTION
Closes #68

## Summary
- /samples/podcast-{1,2,3} でアクセス可能なサンプルページを作成
- OGPメタタグを含めて既存のAPIからメタデータ取得可能
- サムネイル画像をSVGで作成
- 認証なしでアクセス可能

🤖 Generated with [Claude Code](https://claude.ai/code)