### PR TITLE
fix: テレ東BIZのプラットフォームバッジ表示を修正

### DIFF
--- a/components/podcast-card.tsx
+++ b/components/podcast-card.tsx
@@ -17,7 +17,13 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { getPlatformColor, getPriorityColor, getPriorityLabel, type Priority } from "@/lib/utils"
+import {
+  getPlatformColor,
+  getPlatformLabel,
+  getPriorityColor,
+  getPriorityLabel,
+  type Priority,
+} from "@/lib/utils"
 
 type Podcast = {
   id: string
@@ -162,7 +168,7 @@ export function PodcastCard({
           <div className="flex items-center gap-1 mb-2 flex-wrap">
             {podcast.platform && (
               <Badge className={getPlatformColor(podcast.platform)} variant="default">
-                {podcast.platform}
+                {getPlatformLabel(podcast.platform)}
               </Badge>
             )}
             <Badge className={getPriorityColor(podcast.priority)} variant="default">

--- a/components/podcast-list-item.tsx
+++ b/components/podcast-list-item.tsx
@@ -16,7 +16,13 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { getPlatformColor, getPriorityColor, getPriorityLabel, type Priority } from "@/lib/utils"
+import {
+  getPlatformColor,
+  getPlatformLabel,
+  getPriorityColor,
+  getPriorityLabel,
+  type Priority,
+} from "@/lib/utils"
 
 type Podcast = {
   id: string
@@ -183,7 +189,7 @@ export function PodcastListItem({
           <div className="flex items-center gap-1 mt-1 flex-wrap">
             {podcast.platform && (
               <Badge className={getPlatformColor(podcast.platform)} variant="default">
-                <span className="text-xs">{podcast.platform}</span>
+                <span className="text-xs">{getPlatformLabel(podcast.platform)}</span>
               </Badge>
             )}
             <Badge className={getPriorityColor(podcast.priority)} variant="default">

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -60,7 +60,7 @@ describe("getPlatformLabel", () => {
     { platform: "spotify", expected: "Spotify" },
     { platform: "newspicks", expected: "NewsPicks" },
     { platform: "pivot", expected: "Pivot" },
-    { platform: "txbiz", expected: "テレ東Biz" },
+    { platform: "txbiz", expected: "テレ東BIZ" },
     { platform: "other", expected: "その他" },
     { platform: "unknown", expected: "その他" },
     { platform: null, expected: "その他" },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,7 +12,7 @@ export function getPlatformColor(platform: string | null): string {
   if (platformLower.includes("spotify")) return "bg-green-500"
   if (platformLower.includes("newspicks")) return "bg-black"
   if (platformLower.includes("pivot")) return "bg-purple-500"
-  if (platformLower.includes("テレ東biz")) return "bg-red-600"
+  if (platformLower.includes("txbiz")) return "bg-red-600"
   return "bg-gray-500"
 }
 
@@ -80,7 +80,7 @@ export function getPlatformLabel(platform: Platform | string | null): string {
     case "pivot":
       return "Pivot"
     case "txbiz":
-      return "テレ東Biz"
+      return "テレ東BIZ"
     default:
       return "その他"
   }


### PR DESCRIPTION
## Summary
- テレ東BIZのバッジ表示名を「txbiz」から「テレ東BIZ」に変更
- バッジの色を赤色に修正

Closes #100

🤖 Generated with [Claude Code](https://claude.ai/code)