### PR TITLE
feat: Podcast編集機能を追加

### DIFF
--- a/components/podcast-card.tsx
+++ b/components/podcast-card.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { ArrowUpDown, Check, ExternalLink, MoreVertical, Trash2, X } from "lucide-react"
+import { ArrowUpDown, Check, Edit, ExternalLink, MoreVertical, Trash2, X } from "lucide-react"
 import Image from "next/image"
 import { useState } from "react"
 import { PodcastDialog } from "@/components/podcast-dialog"
+import { PodcastEditDialog } from "@/components/podcast-edit-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
@@ -44,6 +45,15 @@ type PodcastCardProps = {
   onDelete: (id: string) => Promise<void>
   onChangePriority: (id: string, newPriority: Priority) => Promise<void>
   onStartWatching: (id: string) => Promise<void>
+  onUpdate: (
+    id: string,
+    updates: {
+      title?: string | null
+      description?: string | null
+      thumbnail_url?: string | null
+      platform?: string | null
+    }
+  ) => Promise<void>
 }
 
 export function PodcastCard({
@@ -52,8 +62,10 @@ export function PodcastCard({
   onDelete,
   onChangePriority,
   onStartWatching,
+  onUpdate,
 }: PodcastCardProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
 
   const handleOpenLink = async (e: React.MouseEvent) => {
     e.preventDefault()
@@ -112,6 +124,11 @@ export function PodcastCard({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+              <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
+                <Edit className="mr-2 size-4" />
+                編集
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => onToggleWatched(podcast.id, podcast.is_watched)}>
                 {podcast.is_watched ? (
                   <>
@@ -189,6 +206,13 @@ export function PodcastCard({
         onDelete={onDelete}
         onChangePriority={onChangePriority}
         onStartWatching={onStartWatching}
+      />
+
+      <PodcastEditDialog
+        podcast={podcast}
+        open={isEditDialogOpen}
+        onOpenChange={setIsEditDialogOpen}
+        onUpdate={onUpdate}
       />
     </>
   )

--- a/components/podcast-edit-dialog.tsx
+++ b/components/podcast-edit-dialog.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import { Loader2 } from "lucide-react"
+import type React from "react"
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+type PodcastEditDialogProps = {
+  podcast: {
+    id: string
+    url: string
+    title: string | null
+    description: string | null
+    thumbnail_url: string | null
+    platform: string | null
+  }
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onUpdate: (
+    id: string,
+    updates: {
+      title?: string | null
+      description?: string | null
+      thumbnail_url?: string | null
+      platform?: string | null
+    }
+  ) => Promise<void>
+}
+
+export function PodcastEditDialog({ podcast, open, onOpenChange, onUpdate }: PodcastEditDialogProps) {
+  const [title, setTitle] = useState(podcast.title || "")
+  const [description, setDescription] = useState(podcast.description || "")
+  const [thumbnailUrl, setThumbnailUrl] = useState(podcast.thumbnail_url || "")
+  const [platform, setPlatform] = useState(podcast.platform || "")
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // ダイアログが開かれたときにフォームをリセット
+  useEffect(() => {
+    if (open) {
+      setTitle(podcast.title || "")
+      setDescription(podcast.description || "")
+      setThumbnailUrl(podcast.thumbnail_url || "")
+      setPlatform(podcast.platform || "")
+      setError(null)
+    }
+  }, [open, podcast])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      await onUpdate(podcast.id, {
+        title: title || null,
+        description: description || null,
+        thumbnail_url: thumbnailUrl || null,
+        platform: platform || null,
+      })
+      onOpenChange(false)
+    } catch (error: unknown) {
+      console.error("Podcast更新エラー:", error)
+      setError(error instanceof Error ? error.message : "Podcastの更新に失敗しました")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Podcastを編集</DialogTitle>
+          <DialogDescription>タイトル、説明、サムネイル、プラットフォームを編集できます</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="edit-url">URL（変更不可）</Label>
+            <Input id="edit-url" type="url" value={podcast.url} disabled className="bg-muted" />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-title">タイトル</Label>
+            <Input
+              id="edit-title"
+              type="text"
+              placeholder="Podcastのタイトル"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-description">説明</Label>
+            <Textarea
+              id="edit-description"
+              placeholder="Podcastの説明"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-thumbnail">サムネイルURL</Label>
+            <Input
+              id="edit-thumbnail"
+              type="url"
+              placeholder="https://..."
+              value={thumbnailUrl}
+              onChange={(e) => setThumbnailUrl(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-platform">プラットフォーム</Label>
+            <Input
+              id="edit-platform"
+              type="text"
+              placeholder="YouTube, Spotify等"
+              value={platform}
+              onChange={(e) => setPlatform(e.target.value)}
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  更新中...
+                </>
+              ) : (
+                "更新"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/podcast-list-item.tsx
+++ b/components/podcast-list-item.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { ArrowUpDown, Check, ExternalLink, MoreVertical, Trash2, X } from "lucide-react"
+import { ArrowUpDown, Check, Edit, ExternalLink, MoreVertical, Trash2, X } from "lucide-react"
 import Image from "next/image"
 import { useState } from "react"
 import { PodcastDialog } from "@/components/podcast-dialog"
+import { PodcastEditDialog } from "@/components/podcast-edit-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -43,6 +44,15 @@ type PodcastListItemProps = {
   onDelete: (id: string) => Promise<void>
   onChangePriority: (id: string, newPriority: Priority) => Promise<void>
   onStartWatching: (id: string) => Promise<void>
+  onUpdate: (
+    id: string,
+    updates: {
+      title?: string | null
+      description?: string | null
+      thumbnail_url?: string | null
+      platform?: string | null
+    }
+  ) => Promise<void>
 }
 
 export function PodcastListItem({
@@ -51,8 +61,10 @@ export function PodcastListItem({
   onDelete,
   onChangePriority,
   onStartWatching,
+  onUpdate,
 }: PodcastListItemProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
 
   const handleClick = () => {
     setIsDialogOpen(true)
@@ -133,6 +145,11 @@ export function PodcastListItem({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+                <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
+                  <Edit className="mr-2 size-4" />
+                  編集
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={() => onToggleWatched(podcast.id, podcast.is_watched)}>
                   {podcast.is_watched ? (
                     <>
@@ -214,6 +231,13 @@ export function PodcastListItem({
         onDelete={onDelete}
         onChangePriority={onChangePriority}
         onStartWatching={onStartWatching}
+      />
+
+      <PodcastEditDialog
+        podcast={podcast}
+        open={isEditDialogOpen}
+        onOpenChange={setIsEditDialogOpen}
+        onUpdate={onUpdate}
       />
     </>
   )

--- a/components/podcast-list.tsx
+++ b/components/podcast-list.tsx
@@ -157,6 +157,27 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
     }
   }
 
+  const handleUpdatePodcast = async (
+    id: string,
+    updates: {
+      title?: string | null
+      description?: string | null
+      thumbnail_url?: string | null
+      platform?: string | null
+    }
+  ) => {
+    const supabase = createClient()
+
+    const { error } = await supabase.from("podcasts").update(updates).eq("id", id)
+
+    if (error) {
+      console.error("[v0] Podcast更新エラー:", error)
+      throw error
+    } else {
+      setPodcasts((prev) => prev.map((p) => (p.id === id ? { ...p, ...updates } : p)))
+    }
+  }
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -279,6 +300,7 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
               onDelete={handleDelete}
               onChangePriority={handleChangePriority}
               onStartWatching={handleStartWatching}
+              onUpdate={handleUpdatePodcast}
             />
           ))}
         </div>
@@ -292,6 +314,7 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
               onDelete={handleDelete}
               onChangePriority={handleChangePriority}
               onStartWatching={handleStartWatching}
+              onUpdate={handleUpdatePodcast}
             />
           ))}
         </div>


### PR DESCRIPTION
## 変更内容

Podcast編集機能を実装しました。

- 3点メニューに「編集」メニュー項目を追加
- タイトル、説明、サムネイル、プラットフォームを編集可能に
- URLは変更不可（表示のみ）
- 優先度は既存の3点メニューで変更可能なため編集ダイアログには含めず

Closes #114

---
Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/Tomodo1773/podcast-queue/actions/runs/21239471648