### PR TITLE
feat: 視聴統計ページの実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ PodQueueは、ポッドキャストをプラットフォーム横断で一元管
 - **グリッド/リスト表示切替**: 好みに合わせて表示形式を選択可能
 - **LINE連携**: LINEにURLを送信するだけでポッドキャストを登録可能。登録結果はFlex Messageで通知
 - **サンプルポッドキャスト**: デモ用のサンプルURLを公開しており、LINE連携の動作確認に利用可能
+- **視聴統計**: 視聴履歴を客観的に把握できる統計ページ。日別・週別・月別の視聴数推移、プラットフォーム別統計、平均視聴頻度などを表示
 
 ## サービスレベル
 
@@ -79,6 +80,7 @@ Next.js 16 (App Router) + Supabase + shadcn/ui で構成されたPodcast管理We
   - `auth/` - ログイン・サインアップページ
     - `auth/sign-up-success/` - サインアップ完了ページ
   - `podcasts/` - Podcast一覧・追加ページ
+    - `podcasts/stats/` - 視聴統計ページ
   - `settings/` - 設定ページ（LINE連携など）
   - `samples/[id]/` - サンプルPodcastページ（OGP対応）
   - `api/fetch-metadata/` - URLからメタデータを取得するAPI Route
@@ -92,6 +94,9 @@ Next.js 16 (App Router) + Supabase + shadcn/ui で構成されたPodcast管理We
   - `add-podcast-form.tsx` - Podcast追加フォーム
   - `podcasts-header.tsx` - Podcastページヘッダー
   - `podcasts-container.tsx` - Podcastページコンテナ
+  - `stats-container.tsx` - 視聴統計ページコンテナ
+  - `stats-header.tsx` - 視聴統計ページヘッダー
+  - `stats-view.tsx` - 視聴統計表示コンポーネント（グラフ・統計情報）
   - `settings-form.tsx` - 設定フォーム（LINE連携）
   - `theme-provider.tsx` - テーマプロバイダー
 - `lib/` - ユーティリティ
@@ -112,6 +117,7 @@ Next.js 16 (App Router) + Supabase + shadcn/ui で構成されたPodcast管理We
 
 - **フロントエンド**: React 19, Next.js 16, Tailwind CSS 4
 - **UI**: shadcn/ui (new-york スタイル), Radix UI, Lucide Icons
+- **グラフ**: recharts
 - **バックエンド**: Supabase (認証 + PostgreSQL)
 - **パスエイリアス**: `@/*` でルートからのインポート
 
@@ -133,3 +139,11 @@ LINEにURLを送信してポッドキャストを登録可能。`/api/line-webho
 ### サンプルポッドキャスト
 
 LINE連携の動作確認用。`/samples/{id}`でOGP対応のデモページを提供。
+
+### 視聴統計
+
+`/podcasts/stats`ページで視聴履歴の統計情報を表示。`getStats` Server Actionで統計データを取得し、rechartsでグラフを描画。以下の情報を提供：
+
+- **基本統計**: 総視聴数、今日・今週・今月の視聴数、平均視聴頻度（日/週）
+- **時系列グラフ**: 日別（過去30日）、週別（過去12週）、月別（過去12ヶ月）の視聴数推移
+- **プラットフォーム別統計**: 各プラットフォームの視聴数と割合（円グラフ）

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ PodQueueは、YouTube、Spotify、NewsPicksなど様々なプラットフォー�
 - **フィルタリング・並び替え** - 視聴状態・優先度でのフィルタリング、追加日順・優先度順での並び替え
 - **グリッド/リスト表示切替** - 好みに合わせて表示形式を選択可能
 - **LINE連携** - LINEにURLを送信するだけでPodcastを自動登録（設定画面からLINE User IDを連携）
+- **視聴統計** - 視聴履歴を客観的に把握できる統計ページ（日別・週別・月別の視聴数推移、プラットフォーム別統計、平均視聴頻度など）
 
 ## サンプルポッドキャスト
 
@@ -31,6 +32,7 @@ PodQueueは、YouTube、Spotify、NewsPicksなど様々なプラットフォー�
 
 - **フロントエンド**: Next.js 16 (App Router), React 19, Tailwind CSS 4
 - **UI**: shadcn/ui, Radix UI, Lucide Icons
+- **グラフ**: recharts
 - **バックエンド**: Supabase (認証 + PostgreSQL)
 
 ## 開発

--- a/app/podcasts/stats/actions.test.ts
+++ b/app/podcasts/stats/actions.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getStats } from "./actions"
+
+// Supabaseクライアントのモック
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            gte: vi.fn(() => ({
+              order: vi.fn(() => ({
+                data: [],
+              })),
+            })),
+          })),
+          gte: vi.fn(() => ({
+            order: vi.fn(() => ({
+              data: [],
+            })),
+          })),
+          count: 0,
+        })),
+        count: 0,
+      })),
+    })),
+  })),
+}))
+
+describe("getStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("統計データの構造が正しい", async () => {
+    const stats = await getStats("test-user-id")
+
+    expect(stats).toHaveProperty("total")
+    expect(stats).toHaveProperty("today")
+    expect(stats).toHaveProperty("thisWeek")
+    expect(stats).toHaveProperty("thisMonth")
+    expect(stats).toHaveProperty("averagePerDay")
+    expect(stats).toHaveProperty("averagePerWeek")
+    expect(stats).toHaveProperty("dailyStats")
+    expect(stats).toHaveProperty("weeklyStats")
+    expect(stats).toHaveProperty("monthlyStats")
+    expect(stats).toHaveProperty("platformStats")
+  })
+
+  it("数値型のフィールドが数値である", async () => {
+    const stats = await getStats("test-user-id")
+
+    expect(typeof stats.total).toBe("number")
+    expect(typeof stats.today).toBe("number")
+    expect(typeof stats.thisWeek).toBe("number")
+    expect(typeof stats.thisMonth).toBe("number")
+    expect(typeof stats.averagePerDay).toBe("number")
+    expect(typeof stats.averagePerWeek).toBe("number")
+  })
+
+  it("配列型のフィールドが配列である", async () => {
+    const stats = await getStats("test-user-id")
+
+    expect(Array.isArray(stats.dailyStats)).toBe(true)
+    expect(Array.isArray(stats.weeklyStats)).toBe(true)
+    expect(Array.isArray(stats.monthlyStats)).toBe(true)
+    expect(Array.isArray(stats.platformStats)).toBe(true)
+  })
+
+  it("dailyStatsの長さが30である", async () => {
+    const stats = await getStats("test-user-id")
+
+    expect(stats.dailyStats.length).toBe(30)
+  })
+
+  it("weeklyStatsの長さが12である", async () => {
+    const stats = await getStats("test-user-id")
+
+    expect(stats.weeklyStats.length).toBe(12)
+  })
+
+  it("monthlyStatsの長さが12である", async () => {
+    const stats = await getStats("test-user-id")
+
+    expect(stats.monthlyStats.length).toBe(12)
+  })
+})

--- a/app/podcasts/stats/actions.ts
+++ b/app/podcasts/stats/actions.ts
@@ -1,0 +1,230 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+
+export type DailyStats = {
+  date: string
+  count: number
+}
+
+export type PlatformStats = {
+  platform: string
+  count: number
+}
+
+export type StatsData = {
+  total: number
+  today: number
+  thisWeek: number
+  thisMonth: number
+  averagePerDay: number
+  averagePerWeek: number
+  dailyStats: DailyStats[]
+  weeklyStats: DailyStats[]
+  monthlyStats: DailyStats[]
+  platformStats: PlatformStats[]
+}
+
+export async function getStats(userId: string): Promise<StatsData> {
+  const supabase = await createClient()
+
+  // 総視聴数
+  const { count: total } = await supabase
+    .from("podcasts")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("is_watched", true)
+
+  // 今日の視聴数
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const { count: todayCount } = await supabase
+    .from("podcasts")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("is_watched", true)
+    .gte("watched_at", today.toISOString())
+
+  // 今週の視聴数（月曜日始まり）
+  const thisWeekStart = new Date()
+  const day = thisWeekStart.getDay()
+  const diff = thisWeekStart.getDate() - day + (day === 0 ? -6 : 1)
+  thisWeekStart.setDate(diff)
+  thisWeekStart.setHours(0, 0, 0, 0)
+  const { count: thisWeekCount } = await supabase
+    .from("podcasts")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("is_watched", true)
+    .gte("watched_at", thisWeekStart.toISOString())
+
+  // 今月の視聴数
+  const thisMonthStart = new Date()
+  thisMonthStart.setDate(1)
+  thisMonthStart.setHours(0, 0, 0, 0)
+  const { count: thisMonthCount } = await supabase
+    .from("podcasts")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("is_watched", true)
+    .gte("watched_at", thisMonthStart.toISOString())
+
+  // 過去30日間の日別視聴数
+  const thirtyDaysAgo = new Date()
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+  thirtyDaysAgo.setHours(0, 0, 0, 0)
+  const { data: dailyData } = await supabase
+    .from("podcasts")
+    .select("watched_at")
+    .eq("user_id", userId)
+    .eq("is_watched", true)
+    .gte("watched_at", thirtyDaysAgo.toISOString())
+    .order("watched_at", { ascending: true })
+
+  // 日別データを集計
+  const dailyMap = new Map<string, number>()
+  for (let i = 0; i < 30; i++) {
+    const date = new Date(thirtyDaysAgo)
+    date.setDate(date.getDate() + i)
+    const dateStr = date.toISOString().split("T")[0]
+    dailyMap.set(dateStr, 0)
+  }
+
+  dailyData?.forEach((item) => {
+    if (item.watched_at) {
+      const dateStr = item.watched_at.split("T")[0]
+      dailyMap.set(dateStr, (dailyMap.get(dateStr) || 0) + 1)
+    }
+  })
+
+  const dailyStats: DailyStats[] = Array.from(dailyMap.entries()).map(([date, count]) => ({
+    date,
+    count,
+  }))
+
+  // 過去12週間の週別視聴数
+  const twelveWeeksAgo = new Date()
+  twelveWeeksAgo.setDate(twelveWeeksAgo.getDate() - 84)
+  twelveWeeksAgo.setHours(0, 0, 0, 0)
+  const { data: weeklyData } = await supabase
+    .from("podcasts")
+    .select("watched_at")
+    .eq("user_id", userId)
+    .eq("is_watched", true)
+    .gte("watched_at", twelveWeeksAgo.toISOString())
+    .order("watched_at", { ascending: true })
+
+  // 週別データを集計（月曜日始まり）
+  const weeklyMap = new Map<string, number>()
+  for (let i = 0; i < 12; i++) {
+    const weekStart = new Date(twelveWeeksAgo)
+    weekStart.setDate(weekStart.getDate() + i * 7)
+    const dateStr = weekStart.toISOString().split("T")[0]
+    weeklyMap.set(dateStr, 0)
+  }
+
+  weeklyData?.forEach((item) => {
+    if (item.watched_at) {
+      const date = new Date(item.watched_at)
+      const weekStart = new Date(date)
+      const dayOfWeek = weekStart.getDay()
+      const diff = weekStart.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1)
+      weekStart.setDate(diff)
+      weekStart.setHours(0, 0, 0, 0)
+
+      // 該当する週を見つけて加算
+      for (const key of weeklyMap.keys()) {
+        const keyDate = new Date(key)
+        const nextWeek = new Date(keyDate)
+        nextWeek.setDate(nextWeek.getDate() + 7)
+        if (weekStart >= keyDate && weekStart < nextWeek) {
+          weeklyMap.set(key, (weeklyMap.get(key) || 0) + 1)
+          break
+        }
+      }
+    }
+  })
+
+  const weeklyStats: DailyStats[] = Array.from(weeklyMap.entries()).map(([date, count]) => ({
+    date,
+    count,
+  }))
+
+  // 過去12ヶ月の月別視聴数
+  const twelveMonthsAgo = new Date()
+  twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 12)
+  twelveMonthsAgo.setDate(1)
+  twelveMonthsAgo.setHours(0, 0, 0, 0)
+  const { data: monthlyData } = await supabase
+    .from("podcasts")
+    .select("watched_at")
+    .eq("user_id", userId)
+    .eq("is_watched", true)
+    .gte("watched_at", twelveMonthsAgo.toISOString())
+    .order("watched_at", { ascending: true })
+
+  // 月別データを集計
+  const monthlyMap = new Map<string, number>()
+  for (let i = 0; i < 12; i++) {
+    const monthStart = new Date(twelveMonthsAgo)
+    monthStart.setMonth(monthStart.getMonth() + i)
+    const dateStr = `${monthStart.getFullYear()}-${String(monthStart.getMonth() + 1).padStart(2, "0")}`
+    monthlyMap.set(dateStr, 0)
+  }
+
+  monthlyData?.forEach((item) => {
+    if (item.watched_at) {
+      const date = new Date(item.watched_at)
+      const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`
+      monthlyMap.set(dateStr, (monthlyMap.get(dateStr) || 0) + 1)
+    }
+  })
+
+  const monthlyStats: DailyStats[] = Array.from(monthlyMap.entries()).map(([date, count]) => ({
+    date,
+    count,
+  }))
+
+  // プラットフォーム別統計
+  const { data: platformData } = await supabase
+    .from("podcasts")
+    .select("platform")
+    .eq("user_id", userId)
+    .eq("is_watched", true)
+
+  const platformMap = new Map<string, number>()
+  platformData?.forEach((item) => {
+    const platform = item.platform || "その他"
+    platformMap.set(platform, (platformMap.get(platform) || 0) + 1)
+  })
+
+  const platformStats: PlatformStats[] = Array.from(platformMap.entries()).map(([platform, count]) => ({
+    platform,
+    count,
+  }))
+
+  // 平均視聴頻度の計算
+  const firstWatchedAt = dailyData?.[0]?.watched_at
+  let averagePerDay = 0
+  let averagePerWeek = 0
+
+  if (firstWatchedAt && total) {
+    const firstDate = new Date(firstWatchedAt)
+    const daysSinceFirst = Math.max(1, Math.floor((Date.now() - firstDate.getTime()) / (1000 * 60 * 60 * 24)))
+    averagePerDay = total / daysSinceFirst
+    averagePerWeek = (total / daysSinceFirst) * 7
+  }
+
+  return {
+    total: total || 0,
+    today: todayCount || 0,
+    thisWeek: thisWeekCount || 0,
+    thisMonth: thisMonthCount || 0,
+    averagePerDay: Number(averagePerDay.toFixed(2)),
+    averagePerWeek: Number(averagePerWeek.toFixed(2)),
+    dailyStats,
+    weeklyStats,
+    monthlyStats,
+    platformStats,
+  }
+}

--- a/app/podcasts/stats/page.tsx
+++ b/app/podcasts/stats/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation"
+import { StatsContainer } from "@/components/stats-container"
+import { createClient } from "@/lib/supabase/server"
+
+export default async function StatsPage() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    redirect("/auth/login")
+  }
+
+  return <StatsContainer userId={user.id} />
+}

--- a/components/podcasts-header.tsx
+++ b/components/podcasts-header.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { LogOut, PlusCircle, Settings } from "lucide-react"
+import { BarChart3, LogOut, PlusCircle, Settings } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -47,6 +47,11 @@ export function PodcastsHeader({ userId, onPodcastAdded, sharedUrl, autoFetch }:
           <Button onClick={() => setOpen(true)}>
             <PlusCircle className="size-4" />
             <span className="hidden sm:inline">Podcastを追加</span>
+          </Button>
+          <Button variant="ghost" size="icon" asChild>
+            <Link href="/podcasts/stats">
+              <BarChart3 className="size-4" />
+            </Link>
           </Button>
           <Button variant="ghost" size="icon" asChild>
             <Link href="/settings">

--- a/components/stats-container.tsx
+++ b/components/stats-container.tsx
@@ -1,0 +1,20 @@
+import { getStats } from "@/app/podcasts/stats/actions"
+import { StatsHeader } from "@/components/stats-header"
+import { StatsView } from "@/components/stats-view"
+
+type StatsContainerProps = {
+  userId: string
+}
+
+export async function StatsContainer({ userId }: StatsContainerProps) {
+  const stats = await getStats(userId)
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-white">
+      <StatsHeader />
+      <main className="container mx-auto px-4 py-8">
+        <StatsView stats={stats} />
+      </main>
+    </div>
+  )
+}

--- a/components/stats-header.tsx
+++ b/components/stats-header.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { ArrowLeft, BarChart3 } from "lucide-react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export function StatsHeader() {
+  return (
+    <header className="border-b bg-gradient-to-r from-purple-50/50 to-blue-50/50">
+      <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <BarChart3 className="size-8 text-purple-600" />
+          <h1 className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
+            視聴統計
+          </h1>
+        </div>
+        <Button variant="ghost" asChild>
+          <Link href="/podcasts">
+            <ArrowLeft className="size-4" />
+            <span className="hidden sm:inline">一覧に戻る</span>
+          </Link>
+        </Button>
+      </div>
+    </header>
+  )
+}

--- a/components/stats-view.tsx
+++ b/components/stats-view.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import type { StatsData } from "@/app/podcasts/stats/actions"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+type StatsViewProps = {
+  stats: StatsData
+}
+
+const COLORS = ["#8b5cf6", "#3b82f6", "#06b6d4", "#10b981", "#f59e0b", "#ef4444"]
+
+export function StatsView({ stats }: StatsViewProps) {
+  const [timePeriod, setTimePeriod] = useState<"daily" | "weekly" | "monthly">("daily")
+
+  const chartData =
+    timePeriod === "daily"
+      ? stats.dailyStats
+      : timePeriod === "weekly"
+        ? stats.weeklyStats
+        : stats.monthlyStats
+
+  const formatDate = (dateStr: string) => {
+    if (timePeriod === "monthly") {
+      const [year, month] = dateStr.split("-")
+      return `${year}/${month}`
+    }
+    const date = new Date(dateStr)
+    if (timePeriod === "weekly") {
+      return `${date.getMonth() + 1}/${date.getDate()}`
+    }
+    return `${date.getMonth() + 1}/${date.getDate()}`
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 基本統計 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>総視聴数</CardDescription>
+            <CardTitle className="text-3xl">{stats.total}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-muted-foreground">累計視聴したポッドキャスト数</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>今日</CardDescription>
+            <CardTitle className="text-3xl">{stats.today}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-muted-foreground">本日視聴した数</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>今週</CardDescription>
+            <CardTitle className="text-3xl">{stats.thisWeek}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-muted-foreground">今週視聴した数（月曜始まり）</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>今月</CardDescription>
+            <CardTitle className="text-3xl">{stats.thisMonth}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-muted-foreground">今月視聴した数</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 平均視聴頻度 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>平均視聴頻度（日）</CardDescription>
+            <CardTitle className="text-3xl">{stats.averagePerDay}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-muted-foreground">1日あたりの平均視聴数</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>平均視聴頻度（週）</CardDescription>
+            <CardTitle className="text-3xl">{stats.averagePerWeek}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-muted-foreground">1週間あたりの平均視聴数</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 時系列グラフ */}
+      <Card>
+        <CardHeader>
+          <CardTitle>視聴履歴推移</CardTitle>
+          <CardDescription>期間ごとの視聴数の推移</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Tabs value={timePeriod} onValueChange={(v) => setTimePeriod(v as typeof timePeriod)}>
+            <TabsList className="grid w-full grid-cols-3">
+              <TabsTrigger value="daily">日別（30日間）</TabsTrigger>
+              <TabsTrigger value="weekly">週別（12週間）</TabsTrigger>
+              <TabsTrigger value="monthly">月別（12ヶ月）</TabsTrigger>
+            </TabsList>
+            <TabsContent value={timePeriod} className="mt-4">
+              <ResponsiveContainer width="100%" height={300}>
+                <BarChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" tickFormatter={formatDate} />
+                  <YAxis />
+                  <Tooltip labelFormatter={(label) => formatDate(String(label))} />
+                  <Bar dataKey="count" fill="#8b5cf6" name="視聴数" />
+                </BarChart>
+              </ResponsiveContainer>
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+
+      {/* プラットフォーム別統計 */}
+      {stats.platformStats.length > 0 && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>プラットフォーム別視聴数</CardTitle>
+              <CardDescription>各プラットフォームの視聴数</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {stats.platformStats.map((stat) => (
+                  <div key={stat.platform} className="flex items-center justify-between">
+                    <span className="text-sm font-medium">{stat.platform}</span>
+                    <span className="text-sm text-muted-foreground">{stat.count}本</span>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>プラットフォーム別割合</CardTitle>
+              <CardDescription>各プラットフォームの視聴割合</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={300}>
+                <PieChart>
+                  <Pie
+                    data={stats.platformStats}
+                    cx="50%"
+                    cy="50%"
+                    labelLine={false}
+                    label
+                    outerRadius={80}
+                    fill="#8884d8"
+                    dataKey="count"
+                    nameKey="platform"
+                  >
+                    {stats.platformStats.map((entry, index) => (
+                      <Cell key={`cell-${entry.platform}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip />
+                </PieChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-dropdown-menu": "2.1.16",
     "@radix-ui/react-label": "2.1.8",
     "@radix-ui/react-slot": "1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@supabase/ssr": "0.8.0",
     "@supabase/supabase-js": "latest",
     "@vercel/analytics": "1.6.1",
@@ -31,6 +32,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^3.7.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: 1.2.4
         version: 1.2.4(@types/react@19.2.9)(react@19.2.3)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@supabase/ssr':
         specifier: 0.8.0
         version: 0.8.0(@supabase/supabase-js@2.91.0)
@@ -53,6 +56,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      recharts:
+        specifier: ^3.7.0
+        version: 3.7.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(redux@5.0.1)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -900,6 +906,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -965,6 +984,17 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     resolution: {integrity: sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA==}
@@ -1094,6 +1124,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@supabase/auth-js@2.91.0':
     resolution: {integrity: sha512-9ywvsKLsxTwv7fvN5fXzP3UfRreqrX2waylTBDu0lkmeHXa8WtSQS9e0WV9FBduiazYqQbgfBQXBNPRPsRgWOQ==}
     engines: {node: '>=20.0.0'}
@@ -1220,6 +1253,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1239,6 +1299,9 @@ packages:
 
   '@types/react@19.2.9':
     resolution: {integrity: sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1356,6 +1419,53 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1373,6 +1483,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-toolkit@1.44.0:
+    resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
+
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
@@ -1384,6 +1497,9 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1439,6 +1555,16 @@ packages:
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
+
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.3:
+    resolution: {integrity: sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1631,6 +1757,21 @@ packages:
     peerDependencies:
       react: ^19.2.3
 
+  react-is@19.2.3:
+    resolution: {integrity: sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==}
+
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -1664,6 +1805,25 @@ packages:
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
+
+  recharts@3.7.0:
+    resolution: {integrity: sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1738,6 +1898,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1796,6 +1959,14 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -2505,6 +2676,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.9
 
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.9)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.9)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.9)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.9)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.9
+      '@types/react-dom': 19.2.3(@types/react@19.2.9)
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.9)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -2554,6 +2741,18 @@ snapshots:
       '@types/react': 19.2.9
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.3
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1)
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     optional: true
@@ -2631,6 +2830,8 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@supabase/auth-js@2.91.0':
     dependencies:
@@ -2758,6 +2959,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -2775,6 +3000,8 @@ snapshots:
   '@types/react@19.2.9':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -2873,6 +3100,46 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  decimal.js-light@2.5.1: {}
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
@@ -2885,6 +3152,8 @@ snapshots:
       tapable: 2.3.0
 
   es-module-lexer@1.7.0: {}
+
+  es-toolkit@1.44.0: {}
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -2920,6 +3189,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  eventemitter3@5.0.4: {}
 
   expect-type@1.3.0: {}
 
@@ -2965,6 +3236,12 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   iceberg-js@0.8.1: {}
+
+  immer@10.2.0: {}
+
+  immer@11.1.3: {}
+
+  internmap@2.0.3: {}
 
   is-extglob@2.1.1: {}
 
@@ -3150,6 +3427,17 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
+  react-is@19.2.3: {}
+
+  react-redux@9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.9
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.9)(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -3178,6 +3466,34 @@ snapshots:
       '@types/react': 19.2.9
 
   react@19.2.3: {}
+
+  recharts@3.7.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.44.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 19.2.3
+      react-redux: 9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
+  reselect@5.1.1: {}
 
   reusify@1.1.0: {}
 
@@ -3280,6 +3596,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -3323,6 +3641,27 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.9
+
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:


### PR DESCRIPTION
## 概要
視聴履歴を客観的に把握できる統計ページを追加しました。

## 主な機能
- 基本統計（総視聴数、今日・今週・今月の視聴数、平均視聴頻度）
- 時系列グラフ（日別・週別・月別の視聴数推移）
- プラットフォーム別統計（視聴数と割合の円グラフ）

Related: #58

Generated with [Claude Code](https://claude.ai/code)