### PR TITLE
サイト内で表示するPodQueueアイコンに角丸を適用

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -69,7 +69,7 @@ export default function LoginPage() {
               alt="PodQueue"
               width={48}
               height={48}
-              className="mx-auto mb-4"
+              className="mx-auto mb-4 rounded-lg"
             />
             <CardTitle className="text-2xl">ログイン</CardTitle>
             <CardDescription>メールアドレスとパスワードを入力してログインしてください</CardDescription>

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -79,7 +79,7 @@ export default function SignUpPage() {
               alt="PodQueue"
               width={48}
               height={48}
-              className="mx-auto mb-4"
+              className="mx-auto mb-4 rounded-lg"
             />
             <CardTitle className="text-2xl">新規登録</CardTitle>
             <CardDescription>新しいアカウントを作成します</CardDescription>

--- a/components/podcasts-header.tsx
+++ b/components/podcasts-header.tsx
@@ -38,7 +38,13 @@ export function PodcastsHeader({ userId, onPodcastAdded, sharedUrl, autoFetch }:
     <header className="border-b bg-gradient-to-r from-purple-50/50 to-blue-50/50">
       <div className="container mx-auto px-4 py-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Image src="/android-chrome-192x192.png" alt="PodQueue" width={32} height={32} />
+          <Image
+            src="/android-chrome-192x192.png"
+            alt="PodQueue"
+            width={32}
+            height={32}
+            className="rounded-lg"
+          />
           <h1 className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
             PodQueue
           </h1>


### PR DESCRIPTION
## 概要
サイト内で表示されるPodQueueアイコンに角丸を適用しました。

## 変更内容
- `components/podcasts-header.tsx` - メインヘッダーのアイコンにTailwind CSSの `rounded-lg` クラスを追加
- `app/auth/login/page.tsx` - ログインページのアイコンに `rounded-lg` を追加
- `app/auth/sign-up/page.tsx` - サインアップページのアイコンに `rounded-lg` を追加

## 注意事項
- 画像ファイル自体は変更していません
- CSSでのみ制御しています
- favicon等の画像は対象外です

Fixes #129

Generated with [Claude Code](https://claude.ai/code)