### PR TITLE
refactor: Google Drive処理をバックグラウンド実行化

### DIFF
--- a/components/podcast-card.tsx
+++ b/components/podcast-card.tsx
@@ -68,11 +68,13 @@ export function PodcastCard({
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
 
-  const handleOpenLink = async (e: React.MouseEvent) => {
+  const handleOpenLink = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    await onStartWatching(podcast.id)
+    // 先に動画を開く
     window.open(podcast.url, "_blank", "noopener,noreferrer")
+    // バックグラウンドで視聴中処理を実行（awaitしない）
+    onStartWatching(podcast.id)
   }
 
   const handleDelete = async () => {

--- a/components/podcast-list-item.tsx
+++ b/components/podcast-list-item.tsx
@@ -78,11 +78,13 @@ export function PodcastListItem({
     }
   }
 
-  const handleOpenLink = async (e: React.MouseEvent) => {
+  const handleOpenLink = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    await onStartWatching(podcast.id)
+    // 先に動画を開く
     window.open(podcast.url, "_blank", "noopener,noreferrer")
+    // バックグラウンドで視聴中処理を実行（awaitしない）
+    onStartWatching(podcast.id)
   }
 
   const handleDelete = async () => {

--- a/components/podcast-list.tsx
+++ b/components/podcast-list.tsx
@@ -155,34 +155,41 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
         }))
       )
 
-      // 4. Google Driveファイル作成（まだ作成していない場合のみ）
+      // 4. Google Driveファイル作成（バックグラウンド実行）
       const podcast = podcasts.find((p) => p.id === id)
       if (podcast && !podcast.google_drive_file_created) {
-        try {
-          const response = await fetch("/api/google-drive/create-file", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              title: podcast.title || podcast.url,
-              url: podcast.url,
-              description: podcast.description || "",
-              platform: podcast.platform || "その他",
-            }),
-          })
-
-          if (response.ok) {
-            // Google Driveファイル作成成功時、フラグを更新
-            await supabase.from("podcasts").update({ google_drive_file_created: true }).eq("id", id)
-
-            setPodcasts((prev) =>
-              prev.map((p) => (p.id === id ? { ...p, google_drive_file_created: true } : p))
-            )
-          }
-        } catch (err) {
-          console.error("Google Driveファイル作成エラー:", err)
-          // エラーでも視聴中操作自体は成功させる
-        }
+        // awaitしない - バックグラウンドで実行
+        createGoogleDriveFile(id, podcast, supabase)
       }
+    }
+  }
+
+  const createGoogleDriveFile = async (
+    id: string,
+    podcast: Podcast,
+    supabase: ReturnType<typeof createClient>
+  ) => {
+    try {
+      const response = await fetch("/api/google-drive/create-file", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: podcast.title || podcast.url,
+          url: podcast.url,
+          description: podcast.description || "",
+          platform: podcast.platform || "その他",
+        }),
+      })
+
+      if (response.ok) {
+        // Google Driveファイル作成成功時、フラグを更新
+        await supabase.from("podcasts").update({ google_drive_file_created: true }).eq("id", id)
+
+        setPodcasts((prev) => prev.map((p) => (p.id === id ? { ...p, google_drive_file_created: true } : p)))
+      }
+    } catch (err) {
+      console.error("Google Driveファイル作成エラー:", err)
+      // エラーでも視聴中操作自体は成功させる
     }
   }
 


### PR DESCRIPTION
### 概要

Google Drive処理をバックグラウンド実行化し、動画再生開始の遅延を解消しました。

### 変更内容

- `podcast-card.tsx`: `handleOpenLink`を同期関数に変更、`window.open()`を先に実行
- `podcast-list-item.tsx`: 同上
- `podcast-list.tsx`: Google Drive処理を別関数に切り出し、awaitせずに実行

### テスト

- ✅ 全テスト通過
- ✅ Lint/format/typecheck/knip すべて通過

Fixes #152

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/Tomodo1773/podcast-queue/actions/runs/21711281105) | [Branch: claude/issue-152-20260205-1221](https://github.com/Tomodo1773/podcast-queue/tree/claude/issue-152-20260205-1221