### PR TITLE
fix: ポッドキャスト追加ダイアログの横スクロール問題を修正

### DIFF
--- a/components/podcasts-header.tsx
+++ b/components/podcasts-header.tsx
@@ -72,7 +72,7 @@ export function PodcastsHeader({ userId, onPodcastAdded, sharedUrl, autoFetch }:
       </div>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto border-t-4 border-t-primary rounded-lg">
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto overflow-x-hidden border-t-4 border-t-primary rounded-lg">
           <DialogHeader>
             <DialogTitle className="bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
               新しいPodcastを追加


### PR DESCRIPTION
### 概要

メタデータ取得後、長いURLや説明文がダイアログ幅を超えて横スクロールが発生する問題を修正。

### 変更内容

- `DialogContent` に `overflow-x-hidden` クラスを追加
- コンテンツがダイアログの幅に収まるように制限

Fixes #167

Generated with [Claude Code](https://claude.ai/code)