### PR TITLE
feat: ポッドキャスト一覧からタグと出演者の表示を削除

### DIFF
--- a/components/podcast-card.tsx
+++ b/components/podcast-card.tsx
@@ -5,7 +5,6 @@ import Image from "next/image"
 import { useState } from "react"
 import { PodcastDialog } from "@/components/podcast-dialog"
 import { PodcastEditDialog } from "@/components/podcast-edit-dialog"
-import { PodcastTags } from "@/components/podcast-tags"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
@@ -202,9 +201,6 @@ export function PodcastCard({
         <CardContent className="flex-1 px-4 pt-3 pb-4">
           <h3 className="font-semibold line-clamp-2 text-pretty mb-1">{podcast.title || "タイトルなし"}</h3>
           {podcast.show_name && <p className="text-xs text-muted-foreground mb-1">{podcast.show_name}</p>}
-          {podcast.speakers && podcast.speakers.length > 0 && (
-            <p className="text-xs text-muted-foreground mb-1">{podcast.speakers.join(", ")}</p>
-          )}
           <div className="flex items-center gap-1 mb-2 flex-wrap">
             {podcast.platform && (
               <Badge className={getPlatformColor(podcast.platform)} variant="default">
@@ -218,7 +214,6 @@ export function PodcastCard({
           {podcast.description && (
             <p className="text-sm text-muted-foreground line-clamp-3 mb-2">{podcast.description}</p>
           )}
-          <PodcastTags tags={podcast.tags} maxTags={5} />
         </CardContent>
       </Card>
 

--- a/components/podcast-list-item.tsx
+++ b/components/podcast-list-item.tsx
@@ -5,7 +5,6 @@ import Image from "next/image"
 import { useState } from "react"
 import { PodcastDialog } from "@/components/podcast-dialog"
 import { PodcastEditDialog } from "@/components/podcast-edit-dialog"
-import { PodcastTags } from "@/components/podcast-tags"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -153,9 +152,6 @@ export function PodcastListItem({
               {podcast.show_name && (
                 <p className="text-xs text-muted-foreground mt-0.5">{podcast.show_name}</p>
               )}
-              {podcast.speakers && podcast.speakers.length > 0 && (
-                <p className="text-xs text-muted-foreground mt-0.5">{podcast.speakers.join(", ")}</p>
-              )}
             </div>
             {/* 3-dot menu */}
             <DropdownMenu>
@@ -245,9 +241,6 @@ export function PodcastListItem({
               {podcast.description}
             </p>
           )}
-
-          {/* Tags */}
-          <PodcastTags tags={podcast.tags} maxTags={6} className="mt-2" />
         </div>
       </div>
 


### PR DESCRIPTION
### 概要

Issue #181の要件に従い、ポッドキャスト一覧画面からタグと出演者の表示を削除しました。

### 変更内容

- `components/podcast-card.tsx`: タグと出演者の表示を削除
- `components/podcast-list-item.tsx`: タグと出演者の表示を削除
- `PodcastTags`コンポーネントのインポートを削除
- 詳細画面では引き続きタグと出演者を確認可能

Fixes #181

——

Generated with [Claude Code](https://claude.ai/code)