### PR TITLE
podcast詳細画面で出演者もバッジ形式で表示するように変更

### DIFF
--- a/components/podcast-dialog.tsx
+++ b/components/podcast-dialog.tsx
@@ -204,9 +204,9 @@ export function PodcastDialog({
               </DropdownMenu>
             </div>
             {podcast.speakers && podcast.speakers.length > 0 && (
-              <div className="flex items-center gap-2">
+              <div className="space-y-2">
                 <span className="text-sm font-semibold text-muted-foreground">出演者:</span>
-                <span className="text-sm">{podcast.speakers.join(", ")}</span>
+                <PodcastTags tags={podcast.speakers} />
               </div>
             )}
             {podcast.tags && podcast.tags.length > 0 && (


### PR DESCRIPTION
これまでカンマ区切りのテキストで表示していた出演者を、
タグと同様にバッジ形式で表示するように改善しました。

https://claude.ai/code/session_01PSCk54c1UoFgWfS2zuwJ2i