### PR TITLE
fix: Statsカードから「本日」を削除し、グリッドレイアウトを3列に調整

### DIFF
--- a/app/podcasts/stats/actions.test.ts
+++ b/app/podcasts/stats/actions.test.ts
@@ -28,7 +28,6 @@ describe("getStats", () => {
     const stats = await getStats("test-user-id")
 
     expect(stats).toHaveProperty("total")
-    expect(stats).toHaveProperty("today")
     expect(stats).toHaveProperty("thisWeek")
     expect(stats).toHaveProperty("thisMonth")
     expect(stats).toHaveProperty("dailyStats")
@@ -39,11 +38,10 @@ describe("getStats", () => {
     expect(stats).toHaveProperty("averagePerWeek")
   })
 
-  it("should return numbers for total, today, thisWeek, thisMonth", async () => {
+  it("should return numbers for total, thisWeek, thisMonth", async () => {
     const stats = await getStats("test-user-id")
 
     expect(typeof stats.total).toBe("number")
-    expect(typeof stats.today).toBe("number")
     expect(typeof stats.thisWeek).toBe("number")
     expect(typeof stats.thisMonth).toBe("number")
     expect(typeof stats.averagePerDay).toBe("number")

--- a/app/podcasts/stats/actions.ts
+++ b/app/podcasts/stats/actions.ts
@@ -14,7 +14,6 @@ export type PlatformStats = {
 
 export type StatsData = {
   total: number
-  today: number
   thisWeek: number
   thisMonth: number
   dailyStats: DailyStats[]
@@ -45,10 +44,6 @@ export async function getStats(userId: string): Promise<StatsData> {
   const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1)
 
   const total = watchedPodcasts.length
-  const todayCount = watchedPodcasts.filter((p) => {
-    const watchedAt = new Date(p.watched_at!)
-    return watchedAt >= today
-  }).length
 
   const thisWeekCount = watchedPodcasts.filter((p) => {
     const watchedAt = new Date(p.watched_at!)
@@ -140,7 +135,6 @@ export async function getStats(userId: string): Promise<StatsData> {
 
   return {
     total,
-    today: todayCount,
     thisWeek: thisWeekCount,
     thisMonth: thisMonthCount,
     dailyStats,

--- a/components/stats-view.tsx
+++ b/components/stats-view.tsx
@@ -53,21 +53,13 @@ export function StatsView({ stats }: StatsViewProps) {
   return (
     <div className="space-y-6">
       {/* 基本統計 */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-3">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">総視聴数</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{stats.total}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">本日</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{stats.today}</div>
           </CardContent>
         </Card>
         <Card>


### PR DESCRIPTION
## 概要

Statsページのカードレイアウトを改善しました。

## 変更内容

- 「本日」カードを削除
- グリッドレイアウトを`3列`に調整（`md:grid-cols-2 lg:grid-cols-4` → `md:grid-cols-3`）
- `StatsData`型から`today`フィールドを削除
- テストコードを更新

Closes #184

———

Generated with [Claude Code](https://claude.ai/code)