### PR TITLE
feat: 視聴済みにした際もGoogle Driveファイル作成を実行

### DIFF
--- a/components/podcast-list.tsx
+++ b/components/podcast-list.tsx
@@ -104,6 +104,11 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
             : p
         )
       )
+
+      // 視聴済みにする場合、Google Driveファイル作成（バックグラウンド実行）
+      if (newStatus) {
+        tryCreateGoogleDriveFile(id)
+      }
     }
   }
 
@@ -135,6 +140,11 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
             : p
         )
       )
+
+      // 視聴済みにする場合、Google Driveファイル作成（バックグラウンド実行）
+      if (newStatus) {
+        tryCreateGoogleDriveFile(id)
+      }
     }
   }
 
@@ -159,6 +169,14 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
       console.error("[v0] 優先度更新エラー:", error)
     } else {
       setPodcasts((prev) => prev.map((p) => (p.id === id ? { ...p, priority: newPriority } : p)))
+    }
+  }
+
+  const tryCreateGoogleDriveFile = (id: string) => {
+    const podcast = podcasts.find((p) => p.id === id)
+    if (podcast && !podcast.google_drive_file_created) {
+      const supabase = createClient()
+      createGoogleDriveFile(id, podcast, supabase)
     }
   }
 
@@ -187,11 +205,7 @@ export function PodcastList({ userId, refreshKey = 0 }: PodcastListProps) {
       )
 
       // 4. Google Driveファイル作成（バックグラウンド実行）
-      const podcast = podcasts.find((p) => p.id === id)
-      if (podcast && !podcast.google_drive_file_created) {
-        // awaitしない - バックグラウンドで実行
-        createGoogleDriveFile(id, podcast, supabase)
-      }
+      tryCreateGoogleDriveFile(id)
     }
   }
 


### PR DESCRIPTION
Google Driveファイル作成ロジックを`tryCreateGoogleDriveFile()`関数として分離し、 以下の3つのケースで呼び出すように変更:
- 視聴中にする場合 (`handleStartWatching`)
- 視聴済みにする場合 (`handleToggleWatched`)
- ステータスを視聴済みに変更する場合 (`handleChangeWatchedStatus`)

これにより、視聴中を経由せずにいきなり視聴済みにした場合でも
Google Driveファイルが作成されるようになりました。

Fixes #168