### PR TITLE
feat: Statsに番組名ごとの円グラフを追加

### DIFF
--- a/app/podcasts/stats/actions.test.ts
+++ b/app/podcasts/stats/actions.test.ts
@@ -34,6 +34,7 @@ describe("getStats", () => {
     expect(stats).toHaveProperty("weeklyStats")
     expect(stats).toHaveProperty("monthlyStats")
     expect(stats).toHaveProperty("platformStats")
+    expect(stats).toHaveProperty("showNameStats")
     expect(stats).toHaveProperty("averagePerDay")
     expect(stats).toHaveProperty("averagePerWeek")
   })
@@ -55,6 +56,7 @@ describe("getStats", () => {
     expect(Array.isArray(stats.weeklyStats)).toBe(true)
     expect(Array.isArray(stats.monthlyStats)).toBe(true)
     expect(Array.isArray(stats.platformStats)).toBe(true)
+    expect(Array.isArray(stats.showNameStats)).toBe(true)
   })
 
   it("should return 30 daily stats", async () => {

--- a/components/stats-view.tsx
+++ b/components/stats-view.tsx
@@ -192,6 +192,57 @@ export function StatsView({ stats }: StatsViewProps) {
           </div>
         </CardContent>
       </Card>
+
+      {/* 番組別視聴数 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>番組別視聴数</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <div className="space-y-2">
+                {stats.showNameStats.map((stat) => (
+                  <div key={stat.showName} className="flex items-center justify-between gap-2">
+                    <span className="text-sm truncate" title={stat.showName}>
+                      {stat.showName}
+                    </span>
+                    <span className="text-sm font-medium">{stat.count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div>
+              <ResponsiveContainer width="100%" height={300}>
+                <PieChart>
+                  <Pie
+                    data={stats.showNameStats}
+                    cx="50%"
+                    cy="50%"
+                    labelLine={false}
+                    // biome-ignore lint/suspicious/noExplicitAny: recharts型定義の都合上必要
+                    label={(entry: any) => `${entry.showName}: ${entry.count}`}
+                    outerRadius={80}
+                    fill="#8884d8"
+                    dataKey="count"
+                  >
+                    {stats.showNameStats.map((item, index) => (
+                      <Cell key={item.showName} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    // biome-ignore lint/suspicious/noExplicitAny: recharts型定義の都合上必要
+                    formatter={(value: any, _name: any, props: any) => [
+                      `${value}回視聴`,
+                      props.payload?.showName ?? "不明",
+                    ]}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }


### PR DESCRIPTION
Closes #183

番組名ごとの視聴統計を円グラフで表示する機能を追加しました。

**実装内容:**
- showNameStats型を追加し番組名別の統計を集計
- 上位10件を個別表示、11件目以降は「その他」にまとめる
- stats-viewに番組名別円グラフのカードを追加
- テストにshowNameStatsの検証を追加

Generated with [Claude Code](https://claude.ai/code)