### PR TITLE
fix: YouTube /live/ URLの要約生成をスキップ

### DIFF
--- a/lib/gemini/__tests__/update-podcast-metadata.test.ts
+++ b/lib/gemini/__tests__/update-podcast-metadata.test.ts
@@ -131,4 +131,46 @@ describe("updatePodcastMetadata", () => {
     expect(result).toEqual({ tags: mockTags, speakers: mockSpeakers, summary: null })
     expect(mockGenerateYoutubeSummary).not.toHaveBeenCalled()
   })
+
+  it("YouTubeサブドメイン（m.youtube.com）の場合もYouTube要約を生成する", async () => {
+    const mockTags = ["技術", "AI"]
+    const mockSpeakers = ["佐藤花子"]
+    const mockSummary = "- セクション1\n\t- 内容1\n\t- 内容2"
+    mockGenerateMetadata.mockResolvedValue({ tags: mockTags, speakers: mockSpeakers })
+    mockGenerateYoutubeSummary.mockResolvedValue(mockSummary)
+
+    const supabase = createMockSupabase()
+
+    const result = await updatePodcastMetadata(
+      supabase as never,
+      "podcast-1",
+      "テストタイトル",
+      "テスト説明",
+      "youtube",
+      "https://m.youtube.com/watch?v=test"
+    )
+
+    expect(result).toEqual({ tags: mockTags, speakers: mockSpeakers, summary: mockSummary })
+    expect(mockGenerateYoutubeSummary).toHaveBeenCalledWith("https://m.youtube.com/watch?v=test")
+  })
+
+  it("YouTubeサブドメイン（m.youtube.com）で /live/ URLの場合はYouTube要約を生成しない", async () => {
+    const mockTags = ["技術", "AI"]
+    const mockSpeakers = ["佐藤花子"]
+    mockGenerateMetadata.mockResolvedValue({ tags: mockTags, speakers: mockSpeakers })
+
+    const supabase = createMockSupabase()
+
+    const result = await updatePodcastMetadata(
+      supabase as never,
+      "podcast-1",
+      "テストタイトル",
+      "テスト説明",
+      "youtube",
+      "https://m.youtube.com/live/SO76xQ54Rg8"
+    )
+
+    expect(result).toEqual({ tags: mockTags, speakers: mockSpeakers, summary: null })
+    expect(mockGenerateYoutubeSummary).not.toHaveBeenCalled()
+  })
 })

--- a/lib/gemini/update-podcast-metadata.ts
+++ b/lib/gemini/update-podcast-metadata.ts
@@ -30,8 +30,8 @@ export async function updatePodcastMetadata(
         const isYouTubeHost =
           hostname === "youtube.com" ||
           hostname === "www.youtube.com" ||
-          hostname === "youtu.be" ||
-          hostname === "www.youtu.be"
+          hostname.endsWith(".youtube.com") ||
+          hostname === "youtu.be"
 
         // /live/ URLはGemini APIで非対応のためスキップ
         if (isYouTubeHost && parsedUrl.pathname.startsWith("/live/")) {


### PR DESCRIPTION
YouTube `/live/` URL形式（https://www.youtube.com/live/VIDEO_ID）は
Gemini APIで非対応のため、要約生成時にスキップするよう修正。

Fixes #202

---

Generated with [Claude Code](https://claude.ai/code)