### PR TITLE
feat: NewsPicksのポッドキャストタイトルから番組名プレフィックスを除去

### DIFF
--- a/lib/__tests__/metadata.test.ts
+++ b/lib/__tests__/metadata.test.ts
@@ -4,6 +4,7 @@ import {
   extractNewsPicksShowName,
   extractSpotifyId,
   extractYouTubeVideoId,
+  removeNewsPicksShowNamePrefix,
 } from "@/lib/metadata/fetcher"
 
 describe("extractYouTubeVideoId", () => {
@@ -166,6 +167,40 @@ describe("extractNewsPicksShowName", () => {
 
     it("空文字列の場合はnullを返す", () => {
       expect(extractNewsPicksShowName("")).toBeNull()
+    })
+  })
+})
+
+describe("removeNewsPicksShowNamePrefix", () => {
+  describe("番組名プレフィックスを除去できる", () => {
+    it("テックニュース最前線の形式", () => {
+      expect(
+        removeNewsPicksShowNamePrefix(
+          "テックニュース最前線 | 【完全解説】「SaaS全滅」の真相、全部教えます - NewsPicks"
+        )
+      ).toBe("【完全解説】「SaaS全滅」の真相、全部教えます - NewsPicks")
+    })
+
+    it("ビジネスのツボの形式", () => {
+      expect(
+        removeNewsPicksShowNamePrefix("ビジネスのツボ | スタートアップ投資のトレンドを語る - NewsPicks")
+      ).toBe("スタートアップ投資のトレンドを語る - NewsPicks")
+    })
+
+    it("スペースが多い場合も正しく除去", () => {
+      expect(removeNewsPicksShowNamePrefix("架空の番組   |   エピソード名 - NewsPicks")).toBe(
+        "エピソード名 - NewsPicks"
+      )
+    })
+  })
+
+  describe("無効な形式", () => {
+    it("| が含まれないタイトルの場合はそのまま返す", () => {
+      expect(removeNewsPicksShowNamePrefix("タイトルのみ")).toBe("タイトルのみ")
+    })
+
+    it("空文字列の場合はそのまま返す", () => {
+      expect(removeNewsPicksShowNamePrefix("")).toBe("")
     })
   })
 })

--- a/lib/metadata/fetcher.ts
+++ b/lib/metadata/fetcher.ts
@@ -130,6 +130,14 @@ export function extractNewsPicksShowName(title: string): string | null {
 }
 
 /**
+ * NewsPicksのタイトルから番組名プレフィックスを除去する関数
+ * "番組名 | エピソード名 - NewsPicks" → "エピソード名 - NewsPicks"
+ */
+export function removeNewsPicksShowNamePrefix(title: string): string {
+  return title.replace(/^.+?\s*\|\s*/, "")
+}
+
+/**
  * HTMLエンティティをデコードする関数
  * OGPメタタグに含まれる主要なHTMLエンティティ（&quot;、&amp;、&lt;、&gt;、&apos;など）をデコード
  */
@@ -353,7 +361,8 @@ export async function fetchMetadata(url: string): Promise<Metadata> {
     ) {
       const ogpData = await fetchOgpMetadata(url)
       const showName = extractNewsPicksShowName(ogpData.title)
-      return { ...ogpData, showName }
+      const title = removeNewsPicksShowNamePrefix(ogpData.title)
+      return { ...ogpData, title, showName }
     }
   } catch {
     // URLのパースに失敗した場合は無視してOGP取得へ


### PR DESCRIPTION
## 概要

NewsPicksのポッドキャストタイトルから番組名プレフィックスを除去する機能を実装しました。

## 変更内容

- `removeNewsPicksShowNamePrefix`関数を追加
- NewsPicks URLの処理時にタイトルから番組名を除去
- テストケースを追加（架空の番組名使用）

Closes #215

🤖 Generated with [Claude Code](https://claude.ai/code)