### PR TITLE
fix: Google Drive認証切れ時の再連携ボタン動作を修正

### DIFF
--- a/components/settings-form.tsx
+++ b/components/settings-form.tsx
@@ -356,11 +356,7 @@ export function SettingsForm({
                   >
                     再連携
                   </Button>
-                  <Button
-                    variant="outline"
-                    onClick={handleDriveUnlink}
-                    disabled={driveLoading || showReauthAlert}
-                  >
+                  <Button variant="outline" onClick={handleDriveUnlink} disabled={driveLoading}>
                     <Trash2 className="size-4" />
                     連携解除
                   </Button>


### PR DESCRIPTION
## 概要
Google Driveの認証切れ時に「再連携」ボタンがグレーアウトする問題と、再連携時にフォルダIDがリセットされる問題を修正しました。

## 変更内容
- 再連携ボタンの`asChild`を廃止し、`disabled`が効くように修正
- 認証切れ時のボタン状態制御を追加
- OAuthコールバックで既存のフォルダIDを保持するように修正
- テストコードを追加

Fixes #224

----
Generated with [Claude Code](https://claude.ai/code)