### PR TITLE
refactor: ログサニタイズ処理をsanitizeForLog関数に共通化

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
   getPriorityOrder,
   type Platform,
   type Priority,
+  sanitizeForLog,
 } from "@/lib/utils"
 
 describe("detectPlatform", () => {
@@ -96,5 +97,29 @@ describe("getPriorityOrder", () => {
 
   it.each(testCases)("$priority のソート順は $expected を返す", ({ priority, expected }) => {
     expect(getPriorityOrder(priority)).toBe(expected)
+  })
+})
+
+describe("sanitizeForLog", () => {
+  it("改行文字を除去できる", () => {
+    expect(sanitizeForLog("hello\nworld")).toBe("helloworld")
+    expect(sanitizeForLog("hello\rworld")).toBe("helloworld")
+    expect(sanitizeForLog("hello\r\nworld")).toBe("helloworld")
+  })
+
+  it("改行文字がない文字列はそのまま返す", () => {
+    expect(sanitizeForLog("hello world")).toBe("hello world")
+  })
+
+  it("undefinedは空文字列を返す", () => {
+    expect(sanitizeForLog(undefined)).toBe("")
+  })
+
+  it("nullは空文字列を返す", () => {
+    expect(sanitizeForLog(null)).toBe("")
+  })
+
+  it("空文字列は空文字列を返す", () => {
+    expect(sanitizeForLog("")).toBe("")
   })
 })

--- a/lib/gemini/update-podcast-metadata.ts
+++ b/lib/gemini/update-podcast-metadata.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
+import { sanitizeForLog } from "@/lib/utils"
 import { generateMetadata } from "./generate-metadata"
 import { generateYoutubeSummary } from "./generate-youtube-summary"
 
@@ -16,8 +17,7 @@ export async function updatePodcastMetadata(
 ): Promise<{ tags: string[]; speakers: string[]; summary: string | null }> {
   console.log("[updatePodcastMetadata] Starting for podcast:", podcastId)
   console.log("[updatePodcastMetadata] Title:", title)
-  // platformはユーザー入力のため、ログインジェクション対策として改行文字を除去
-  console.log("[updatePodcastMetadata] Platform:", platform?.replace(/[\r\n]/g, ""))
+  console.log("[updatePodcastMetadata] Platform:", sanitizeForLog(platform))
 
   // YouTube 要約生成を行うかどうかの判定（URL のホスト名が YouTube か検証）
   const shouldGenerateYoutubeSummary =
@@ -37,17 +37,16 @@ export async function updatePodcastMetadata(
         if (isYouTubeHost && parsedUrl.pathname.startsWith("/live/")) {
           console.warn(
             "[updatePodcastMetadata] /live/ URL is not supported for YouTube summary, skipping:",
-            url?.replace(/[\r\n]/g, "")
+            sanitizeForLog(url)
           )
           return false
         }
 
         return isYouTubeHost
       } catch {
-        // urlはユーザー入力のため、ログインジェクション対策として改行文字を除去
         console.warn(
           "[updatePodcastMetadata] Invalid URL for YouTube summary, skipping:",
-          url?.replace(/[\r\n]/g, "")
+          sanitizeForLog(url)
         )
         return false
       }
@@ -63,8 +62,7 @@ export async function updatePodcastMetadata(
   console.log("[updatePodcastMetadata] Generated tags:", tags.length)
   console.log("[updatePodcastMetadata] Generated speakers:", speakers.length)
   console.log("[updatePodcastMetadata] Generated YouTube summary:", youtubeSummary ? "yes" : "no")
-  // podcastIdはユーザー入力のため、ログインジェクション対策として改行文字を除去
-  console.log("[updatePodcastMetadata] Podcast ID:", podcastId.replace(/[\r\n]/g, ""))
+  console.log("[updatePodcastMetadata] Podcast ID:", sanitizeForLog(podcastId))
 
   const updateData: Record<string, unknown> = {}
   if (tags.length > 0) updateData.tags = tags
@@ -76,23 +74,17 @@ export async function updatePodcastMetadata(
 
     if (updateError) {
       // podcastIdはユーザー入力のため、ログインジェクション対策として改行文字を除去
-      console.error(
-        "[updatePodcastMetadata] Failed to update DB for podcast:",
-        podcastId.replace(/[\r\n]/g, "")
-      )
+      console.error("[updatePodcastMetadata] Failed to update DB for podcast:", sanitizeForLog(podcastId))
       console.error("[updatePodcastMetadata] Error:", updateError)
       throw new Error("Failed to update metadata")
     }
     // podcastIdはユーザー入力のため、ログインジェクション対策として改行文字を除去
-    console.log(
-      "[updatePodcastMetadata] DB updated successfully for podcast:",
-      podcastId.replace(/[\r\n]/g, "")
-    )
+    console.log("[updatePodcastMetadata] DB updated successfully for podcast:", sanitizeForLog(podcastId))
   } else {
     // podcastIdはユーザー入力のため、ログインジェクション対策として改行文字を除去
     console.warn(
       "[updatePodcastMetadata] No tags, speakers, or summary generated for podcast, skipping DB update. Podcast ID:",
-      podcastId.replace(/[\r\n]/g, "")
+      sanitizeForLog(podcastId)
     )
   }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -89,3 +89,11 @@ export function getPlatformLabel(platform: Platform | null): string {
   const option = PLATFORM_OPTIONS.find((opt) => opt.value === platform)
   return option ? option.label : "その他"
 }
+
+/**
+ * ログインジェクション対策として改行文字を除去する
+ */
+export function sanitizeForLog(text: string | undefined | null): string {
+  if (!text) return ""
+  return text.replace(/[\r\n]/g, "")
+}


### PR DESCRIPTION
## 概要

ログインジェクション対策のサニタイズ処理を共通化しました。

## 変更内容

- `lib/utils.ts`: `sanitizeForLog()` ヘルパー関数を追加
- `lib/gemini/update-podcast-metadata.ts`: 5箇所の `.replace(/[\r\n]/g, "")` を `sanitizeForLog()` に置換
- `lib/__tests__/utils.test.ts`: `sanitizeForLog()` のテストケースを追加

## 効果

- DRY原則に準拠し、コードの重複を削減
- サニタイズ処理の一貫性を保証
- テストカバレッジの向上

Closes #234

---
Generated with [Claude Code](https://claude.ai/code)