### PR TITLE
feat: Notion連携機能を追加

### DIFF
--- a/app/api/auth/notion/callback/route.ts
+++ b/app/api/auth/notion/callback/route.ts
@@ -1,0 +1,94 @@
+import { cookies } from "next/headers"
+import { type NextRequest, NextResponse } from "next/server"
+import { encrypt } from "@/lib/crypto"
+import { exchangeCodeForTokens } from "@/lib/notion/oauth"
+import { createClient } from "@/lib/supabase/server"
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const code = searchParams.get("code")
+  const state = searchParams.get("state")
+  const error = searchParams.get("error")
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ""
+
+  if (error) {
+    return NextResponse.redirect(
+      new URL(`/settings?error=${encodeURIComponent("Notion認証がキャンセルされました")}`, baseUrl)
+    )
+  }
+
+  if (!code || !state) {
+    return NextResponse.redirect(
+      new URL(`/settings?error=${encodeURIComponent("認証パラメータが不正です")}`, baseUrl)
+    )
+  }
+
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.redirect(new URL("/auth/login", baseUrl))
+  }
+
+  const cookieStore = await cookies()
+  const storedState = cookieStore.get("oauth_state")?.value
+
+  if (!storedState || state !== storedState) {
+    cookieStore.delete("oauth_state")
+    return NextResponse.redirect(
+      new URL(`/settings?error=${encodeURIComponent("認証状態が不正です")}`, baseUrl)
+    )
+  }
+
+  cookieStore.delete("oauth_state")
+
+  try {
+    const tokens = await exchangeCodeForTokens(code)
+    const encryptedAccessToken = encrypt(tokens.access_token)
+
+    // 既存の設定を取得してdatabase_idを保持
+    const { data: existingSettings, error: existingSettingsError } = await supabase
+      .from("notion_settings")
+      .select("database_id")
+      .eq("user_id", user.id)
+      .single()
+
+    if (existingSettingsError && existingSettingsError.code !== "PGRST116") {
+      console.error("Notion既存設定の取得に失敗:", existingSettingsError)
+      return NextResponse.redirect(
+        new URL(`/settings?error=${encodeURIComponent("設定の取得に失敗しました")}`, baseUrl)
+      )
+    }
+
+    const { error: upsertError } = await supabase.from("notion_settings").upsert(
+      {
+        user_id: user.id,
+        encrypted_access_token: encryptedAccessToken,
+        workspace_name: tokens.workspace_name,
+        database_id: existingSettings?.database_id || null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id" }
+    )
+
+    if (upsertError) {
+      console.error("Notion設定の保存に失敗:", upsertError)
+      return NextResponse.redirect(
+        new URL(`/settings?error=${encodeURIComponent("設定の保存に失敗しました")}`, baseUrl)
+      )
+    }
+
+    return NextResponse.redirect(
+      new URL(`/settings?notion_success=${encodeURIComponent("Notionと連携しました")}`, baseUrl)
+    )
+  } catch (err) {
+    console.error("Notion OAuth処理でエラー:", err)
+    return NextResponse.redirect(
+      new URL(`/settings?error=${encodeURIComponent("認証処理に失敗しました")}`, baseUrl)
+    )
+  }
+}

--- a/app/api/auth/notion/route.ts
+++ b/app/api/auth/notion/route.ts
@@ -1,0 +1,32 @@
+import { randomBytes } from "node:crypto"
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+import { getNotionAuthUrl } from "@/lib/notion/oauth"
+import { createClient } from "@/lib/supabase/server"
+
+export async function GET() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.redirect(new URL("/auth/login", process.env.NEXT_PUBLIC_APP_URL))
+  }
+
+  const state = randomBytes(32).toString("hex")
+
+  const cookieStore = await cookies()
+  cookieStore.set("oauth_state", state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 600,
+    path: "/",
+  })
+
+  const authUrl = getNotionAuthUrl(state)
+
+  return NextResponse.redirect(authUrl)
+}

--- a/app/api/notion/create-database/route.ts
+++ b/app/api/notion/create-database/route.ts
@@ -1,0 +1,62 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { createNotionDatabase } from "@/lib/notion/notion"
+import { NotionAuthError } from "@/lib/notion/notion-auth"
+import { createClient } from "@/lib/supabase/server"
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 })
+  }
+
+  try {
+    const { parentPageId } = await request.json()
+
+    if (!parentPageId) {
+      return NextResponse.json({ error: "親ページIDが必要です" }, { status: 400 })
+    }
+
+    // データベースIDのチェックをスキップして直接アクセストークンを取得
+    const { data: settings, error: settingsError } = await supabase
+      .from("notion_settings")
+      .select("encrypted_access_token")
+      .eq("user_id", user.id)
+      .single()
+
+    if (settingsError || !settings) {
+      throw new NotionAuthError("Notion連携が設定されていません", 400)
+    }
+
+    const { decrypt } = await import("@/lib/crypto")
+    const accessToken = decrypt(settings.encrypted_access_token)
+
+    const databaseId = await createNotionDatabase(accessToken, parentPageId)
+
+    // database_idを保存
+    const { error: updateError } = await supabase
+      .from("notion_settings")
+      .update({ database_id: databaseId, updated_at: new Date().toISOString() })
+      .eq("user_id", user.id)
+
+    if (updateError) {
+      throw updateError
+    }
+
+    return NextResponse.json({ success: true, databaseId })
+  } catch (error) {
+    if (error instanceof NotionAuthError) {
+      return NextResponse.json(
+        { error: error.message, ...(error.code && { code: error.code }) },
+        { status: error.statusCode }
+      )
+    }
+
+    console.error("Notionデータベース作成エラー:", error)
+    return NextResponse.json({ error: "データベース作成に失敗しました" }, { status: 500 })
+  }
+}

--- a/app/api/notion/create-page/route.ts
+++ b/app/api/notion/create-page/route.ts
@@ -1,0 +1,35 @@
+import { type NextRequest, NextResponse } from "next/server"
+import type { PodcastData } from "@/lib/google/drive"
+import { createNotionPage } from "@/lib/notion/notion"
+import { getNotionAuth, NotionAuthError } from "@/lib/notion/notion-auth"
+import { createClient } from "@/lib/supabase/server"
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 })
+  }
+
+  try {
+    const body: PodcastData = await request.json()
+    const { accessToken, databaseId } = await getNotionAuth(supabase, user.id)
+    const pageId = await createNotionPage(accessToken, databaseId, body)
+
+    return NextResponse.json({ success: true, pageId })
+  } catch (error) {
+    if (error instanceof NotionAuthError) {
+      return NextResponse.json(
+        { error: error.message, ...(error.code && { code: error.code }) },
+        { status: error.statusCode }
+      )
+    }
+
+    console.error("Notionページ作成エラー:", error)
+    return NextResponse.json({ error: "ページ作成に失敗しました" }, { status: 500 })
+  }
+}

--- a/app/api/notion/export-watched/route.ts
+++ b/app/api/notion/export-watched/route.ts
@@ -1,0 +1,110 @@
+import { type NextRequest, NextResponse } from "next/server"
+import type { PodcastData } from "@/lib/google/drive"
+import { createNotionPage } from "@/lib/notion/notion"
+import { getNotionAuth, NotionAuthError } from "@/lib/notion/notion-auth"
+import { createClient } from "@/lib/supabase/server"
+
+export async function POST(_request: NextRequest) {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 })
+  }
+
+  try {
+    const { accessToken, databaseId } = await getNotionAuth(supabase, user.id)
+
+    // 視聴済みかつページ未作成のPodcastを取得
+    const { data: podcasts, error: podcastsError } = await supabase
+      .from("podcasts")
+      .select("*")
+      .eq("user_id", user.id)
+      .eq("is_watched", true)
+      .eq("notion_page_created", false)
+      .order("watched_at", { ascending: false })
+
+    if (podcastsError) {
+      throw podcastsError
+    }
+
+    if (!podcasts || podcasts.length === 0) {
+      return NextResponse.json({
+        success: true,
+        message: "すべての視聴済みPodcastはエクスポート済みです",
+        stats: { total: 0, success: 0, failed: 0 },
+      })
+    }
+
+    let successCount = 0
+    let failedCount = 0
+    const errors: Array<{ podcastId: string; title: string; error: string }> = []
+
+    for (const podcast of podcasts) {
+      try {
+        const podcastData: PodcastData = {
+          title: podcast.title,
+          url: podcast.url,
+          description: podcast.description || "",
+          platform: podcast.platform,
+          show_name: podcast.show_name || undefined,
+          tags: podcast.tags || undefined,
+          speakers: podcast.speakers || undefined,
+          summary: podcast.summary || undefined,
+          thumbnail_url: podcast.thumbnail_url || undefined,
+        }
+
+        await createNotionPage(accessToken, databaseId, podcastData)
+
+        const { error: updateError } = await supabase
+          .from("podcasts")
+          .update({ notion_page_created: true, updated_at: new Date().toISOString() })
+          .eq("id", podcast.id)
+
+        if (updateError) {
+          throw updateError
+        }
+
+        successCount++
+      } catch (error) {
+        console.error(`Podcast ${podcast.id} のNotionページ作成に失敗:`, error)
+        failedCount++
+        errors.push({
+          podcastId: podcast.id,
+          title: podcast.title,
+          error: error instanceof Error ? error.message : "不明なエラー",
+        })
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: `エクスポートが完了しました（成功: ${successCount}件、失敗: ${failedCount}件）`,
+      stats: {
+        total: podcasts.length,
+        success: successCount,
+        failed: failedCount,
+      },
+      errors: errors.length > 0 ? errors : undefined,
+    })
+  } catch (error) {
+    if (error instanceof NotionAuthError) {
+      return NextResponse.json(
+        { error: error.message, ...(error.code && { code: error.code }) },
+        { status: error.statusCode }
+      )
+    }
+
+    console.error("Notionエクスポートエラー:", error)
+    return NextResponse.json(
+      {
+        error: "エクスポートに失敗しました",
+        details: error instanceof Error ? error.message : "不明なエラー",
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -29,6 +29,13 @@ export default async function SettingsPage() {
     .eq("user_id", user.id)
     .single()
 
+  // Notion連携情報を取得
+  const { data: notionSettings } = await supabase
+    .from("notion_settings")
+    .select("database_id, workspace_name, encrypted_access_token")
+    .eq("user_id", user.id)
+    .single()
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50/30 to-blue-50/30">
       <header className="border-b bg-white/80 backdrop-blur-sm">
@@ -51,6 +58,9 @@ export default async function SettingsPage() {
           initialDriveFolderId={driveSettings?.folder_id || ""}
           isDriveLinked={!!driveSettings}
           hasAuthError={!!driveSettings && !driveSettings.encrypted_refresh_token}
+          isNotionLinked={!!notionSettings}
+          initialNotionDatabaseId={notionSettings?.database_id || ""}
+          notionWorkspaceName={notionSettings?.workspace_name || ""}
         />
       </main>
     </div>

--- a/components/settings-form.tsx
+++ b/components/settings-form.tsx
@@ -17,6 +17,9 @@ type SettingsFormProps = {
   initialDriveFolderId: string
   isDriveLinked: boolean
   hasAuthError: boolean
+  isNotionLinked: boolean
+  initialNotionDatabaseId: string
+  notionWorkspaceName: string
 }
 
 export function SettingsForm({
@@ -25,6 +28,9 @@ export function SettingsForm({
   initialDriveFolderId,
   isDriveLinked,
   hasAuthError,
+  isNotionLinked,
+  initialNotionDatabaseId,
+  notionWorkspaceName,
 }: SettingsFormProps) {
   const searchParams = useSearchParams()
   const [lineUserId, setLineUserId] = useState(initialLineUserId)
@@ -46,15 +52,31 @@ export function SettingsForm({
   const [exportLoading, setExportLoading] = useState(false)
   const [showReauthAlert, setShowReauthAlert] = useState(hasAuthError)
 
+  // Notion連携用のstate
+  const [isNotionConnected, setIsNotionConnected] = useState(isNotionLinked)
+  const [notionDatabaseId, setNotionDatabaseId] = useState(initialNotionDatabaseId)
+  const [notionParentPageId, setNotionParentPageId] = useState("")
+  const [notionLoading, setNotionLoading] = useState(false)
+  const [notionMessage, setNotionMessage] = useState<{
+    type: "success" | "error"
+    text: string
+  } | null>(null)
+  const [notionExportLoading, setNotionExportLoading] = useState(false)
+
   // URLパラメータからメッセージを取得
   useEffect(() => {
     const success = searchParams.get("success")
     const error = searchParams.get("error")
+    const notionSuccess = searchParams.get("notion_success")
     const reauth = searchParams.get("reauth")
     if (success) {
       setDriveMessage({ type: "success", text: success })
       setIsDriveConnected(true)
       setShowReauthAlert(false)
+    }
+    if (notionSuccess) {
+      setNotionMessage({ type: "success", text: notionSuccess })
+      setIsNotionConnected(true)
     }
     if (error) {
       setDriveMessage({ type: "error", text: error })
@@ -227,6 +249,123 @@ export function SettingsForm({
     }
   }
 
+  const handleNotionCreateDatabase = async () => {
+    if (!notionParentPageId.trim()) {
+      setNotionMessage({ type: "error", text: "親ページIDを入力してください" })
+      return
+    }
+
+    setNotionLoading(true)
+    setNotionMessage(null)
+
+    try {
+      const response = await fetch("/api/notion/create-database", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ parentPageId: notionParentPageId.trim() }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || "データベース作成に失敗しました")
+      }
+
+      setNotionDatabaseId(data.databaseId)
+      setNotionParentPageId("")
+      setNotionMessage({ type: "success", text: "PodQueueデータベースを作成しました" })
+    } catch (error) {
+      setNotionMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "データベース作成に失敗しました",
+      })
+    } finally {
+      setNotionLoading(false)
+    }
+  }
+
+  const handleNotionSaveDatabaseId = async () => {
+    if (!notionDatabaseId.trim()) {
+      setNotionMessage({ type: "error", text: "データベースIDを入力してください" })
+      return
+    }
+
+    setNotionLoading(true)
+    setNotionMessage(null)
+
+    try {
+      const supabase = createClient()
+      const { error } = await supabase
+        .from("notion_settings")
+        .update({ database_id: notionDatabaseId.trim(), updated_at: new Date().toISOString() })
+        .eq("user_id", userId)
+
+      if (error) throw error
+      setNotionMessage({ type: "success", text: "データベースIDを保存しました" })
+    } catch {
+      setNotionMessage({ type: "error", text: "保存に失敗しました" })
+    } finally {
+      setNotionLoading(false)
+    }
+  }
+
+  const handleNotionUnlink = async () => {
+    setNotionLoading(true)
+    setNotionMessage(null)
+
+    try {
+      const supabase = createClient()
+      const { error } = await supabase.from("notion_settings").delete().eq("user_id", userId)
+
+      if (error) throw error
+
+      setNotionDatabaseId("")
+      setIsNotionConnected(false)
+      setNotionMessage({ type: "success", text: "Notion連携を解除しました" })
+    } catch {
+      setNotionMessage({ type: "error", text: "連携解除に失敗しました" })
+    } finally {
+      setNotionLoading(false)
+    }
+  }
+
+  const handleNotionExportWatched = async () => {
+    setNotionExportLoading(true)
+    toast.success("エクスポートを開始しました", {
+      description: "視聴済みデータをNotionに出力しています...",
+    })
+
+    try {
+      const response = await fetch("/api/notion/export-watched", {
+        method: "POST",
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || "エクスポートに失敗しました")
+      }
+
+      if (data.stats.total === 0) {
+        toast.info(data.message)
+      } else if (data.stats.failed > 0) {
+        toast.warning(data.message, {
+          description: `成功: ${data.stats.success}件、失敗: ${data.stats.failed}件`,
+        })
+      } else {
+        toast.success(data.message, {
+          description: `${data.stats.success}件のページを作成しました`,
+        })
+      }
+    } catch (error) {
+      toast.error("エクスポートに失敗しました", {
+        description: error instanceof Error ? error.message : "不明なエラーが発生しました",
+      })
+    } finally {
+      setNotionExportLoading(false)
+    }
+  }
+
   return (
     <div className="space-y-6">
       <Card>
@@ -373,6 +512,118 @@ export function SettingsForm({
                     className="w-full sm:w-auto"
                   >
                     {exportLoading ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Download className="size-4" />
+                    )}
+                    視聴済みデータをエクスポート
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            Notion連携
+            {isNotionConnected && (
+              <span className="text-sm font-normal text-green-600 flex items-center gap-1">
+                <CheckCircle className="size-4" />
+                連携済み{notionWorkspaceName && `（${notionWorkspaceName}）`}
+              </span>
+            )}
+          </CardTitle>
+          <CardDescription>
+            Notionと連携すると、視聴中・視聴済み時に自動でNotionデータベースにページを作成します。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!isNotionConnected ? (
+            <Button asChild>
+              <a href="/api/auth/notion">Notionで連携</a>
+            </Button>
+          ) : (
+            <>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="notionDatabaseId">データベースID</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="notionDatabaseId"
+                      placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                      value={notionDatabaseId}
+                      onChange={(e) => setNotionDatabaseId(e.target.value)}
+                      disabled={notionLoading}
+                    />
+                    <Button onClick={handleNotionSaveDatabaseId} disabled={notionLoading}>
+                      {notionLoading && <Loader2 className="size-4 animate-spin" />}
+                      保存
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    既存のNotionデータベースIDを直接入力するか、下の「データベースを作成」で新規作成してください
+                  </p>
+                </div>
+
+                <div className="border rounded-md p-3 space-y-2 bg-muted/30">
+                  <p className="text-sm font-medium">PodQueueデータベースを新規作成</p>
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="Notionの親ページID"
+                      value={notionParentPageId}
+                      onChange={(e) => setNotionParentPageId(e.target.value)}
+                      disabled={notionLoading}
+                    />
+                    <Button variant="secondary" onClick={handleNotionCreateDatabase} disabled={notionLoading}>
+                      {notionLoading && <Loader2 className="size-4 animate-spin" />}
+                      作成
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    NotionページURLの末尾のID部分を入力してください
+                  </p>
+                </div>
+              </div>
+
+              {notionMessage && (
+                <p
+                  className={`text-sm ${notionMessage.type === "error" ? "text-red-600" : "text-green-600"}`}
+                >
+                  {notionMessage.text}
+                </p>
+              )}
+
+              <div className="flex flex-col gap-4">
+                <div className="flex gap-2">
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      window.location.href = "/api/auth/notion"
+                    }}
+                    disabled={notionLoading}
+                  >
+                    再連携
+                  </Button>
+                  <Button variant="outline" onClick={handleNotionUnlink} disabled={notionLoading}>
+                    <Trash2 className="size-4" />
+                    連携解除
+                  </Button>
+                </div>
+
+                <div className="border-t pt-4">
+                  <p className="text-sm text-muted-foreground mb-3">
+                    過去の視聴済みデータをNotionにエクスポートできます。
+                  </p>
+                  <Button
+                    variant="secondary"
+                    onClick={handleNotionExportWatched}
+                    disabled={notionExportLoading || notionLoading || !notionDatabaseId}
+                    className="w-full sm:w-auto"
+                  >
+                    {notionExportLoading ? (
                       <Loader2 className="size-4 animate-spin" />
                     ) : (
                       <Download className="size-4" />

--- a/lib/__tests__/csv-export.test.ts
+++ b/lib/__tests__/csv-export.test.ts
@@ -16,6 +16,7 @@ function createPodcast(overrides: Partial<Podcast> = {}): Podcast {
     watched_at: null,
     created_at: "2024-01-01T00:00:00Z",
     google_drive_file_created: false,
+    notion_page_created: false,
     show_name: "テスト番組",
     tags: ["タグ1", "タグ2"],
     speakers: ["スピーカー1"],

--- a/lib/__tests__/podcast-filters.test.ts
+++ b/lib/__tests__/podcast-filters.test.ts
@@ -23,6 +23,7 @@ function createPodcast(overrides: Partial<Podcast> = {}): Podcast {
     watched_at: null,
     created_at: "2024-01-01T00:00:00Z",
     google_drive_file_created: false,
+    notion_page_created: false,
     show_name: null,
     tags: [],
     speakers: [],

--- a/lib/notion/__tests__/oauth.test.ts
+++ b/lib/notion/__tests__/oauth.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it } from "vitest"
+import { getNotionAuthUrl } from "../oauth"
+
+describe("getNotionAuthUrl", () => {
+  beforeEach(() => {
+    process.env.NOTION_OAUTH_CLIENT_ID = "test-client-id"
+    process.env.NEXT_PUBLIC_APP_URL = "https://example.com"
+  })
+
+  it("正しいNotion認可URLを生成すること", () => {
+    const url = getNotionAuthUrl("test-state")
+
+    expect(url).toContain("https://api.notion.com/v1/oauth/authorize")
+    expect(url).toContain("client_id=test-client-id")
+    expect(url).toContain("state=test-state")
+    expect(url).toContain("response_type=code")
+    expect(url).toContain("owner=user")
+    expect(url).toContain("redirect_uri=")
+    expect(url).toContain("api%2Fauth%2Fnotion%2Fcallback")
+  })
+
+  it("環境変数が未設定時にエラーをスローすること", () => {
+    delete process.env.NOTION_OAUTH_CLIENT_ID
+
+    expect(() => getNotionAuthUrl("test-state")).toThrow("Notion OAuth環境変数が設定されていません")
+  })
+})

--- a/lib/notion/notion-auth.ts
+++ b/lib/notion/notion-auth.ts
@@ -1,0 +1,37 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { decrypt } from "@/lib/crypto"
+
+export interface NotionAuthResult {
+  accessToken: string
+  databaseId: string
+}
+
+export class NotionAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly code?: string
+  ) {
+    super(message)
+    this.name = "NotionAuthError"
+  }
+}
+
+export async function getNotionAuth(supabase: SupabaseClient, userId: string): Promise<NotionAuthResult> {
+  const { data: settings, error: settingsError } = await supabase
+    .from("notion_settings")
+    .select("*")
+    .eq("user_id", userId)
+    .single()
+
+  if (settingsError || !settings) {
+    throw new NotionAuthError("Notion連携が設定されていません", 400)
+  }
+
+  if (!settings.database_id) {
+    throw new NotionAuthError("NotionデータベースIDが設定されていません", 400)
+  }
+
+  const accessToken = decrypt(settings.encrypted_access_token)
+  return { accessToken, databaseId: settings.database_id }
+}

--- a/lib/notion/notion.ts
+++ b/lib/notion/notion.ts
@@ -1,0 +1,107 @@
+import { generateMarkdownContent, type PodcastData } from "@/lib/google/drive"
+
+const NOTION_API_URL = "https://api.notion.com/v1"
+const NOTION_VERSION = "2022-06-28"
+
+function notionHeaders(accessToken: string) {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+    "Notion-Version": NOTION_VERSION,
+  }
+}
+
+export async function createNotionDatabase(accessToken: string, parentPageId: string): Promise<string> {
+  const response = await fetch(`${NOTION_API_URL}/databases`, {
+    method: "POST",
+    headers: notionHeaders(accessToken),
+    body: JSON.stringify({
+      parent: { type: "page_id", page_id: parentPageId },
+      title: [{ type: "text", text: { content: "PodQueue" } }],
+      properties: {
+        title: { title: {} },
+        date: { date: {} },
+        platform: { rich_text: {} },
+        source: { url: {} },
+        show_name: { rich_text: {} },
+      },
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`Notionデータベース作成に失敗しました: ${error}`)
+  }
+
+  const result = await response.json()
+  return result.id
+}
+
+// Notionのrich_textは2000文字制限があるため分割する
+function splitIntoCodeBlocks(content: string): object[] {
+  const maxLength = 2000
+  const blocks = []
+  for (let i = 0; i < content.length; i += maxLength) {
+    blocks.push({
+      object: "block",
+      type: "code",
+      code: {
+        rich_text: [{ type: "text", text: { content: content.slice(i, i + maxLength) } }],
+        language: "markdown",
+      },
+    })
+  }
+  return blocks
+}
+
+export async function createNotionPage(
+  accessToken: string,
+  databaseId: string,
+  podcast: PodcastData
+): Promise<string> {
+  const jstDate = new Date()
+    .toLocaleDateString("ja-JP", {
+      timeZone: "Asia/Tokyo",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+    .replace(/\//g, "-")
+
+  const content = generateMarkdownContent(podcast)
+
+  const properties: Record<string, unknown> = {
+    title: {
+      title: [{ type: "text", text: { content: podcast.title || podcast.url } }],
+    },
+    date: { date: { start: jstDate } },
+    platform: {
+      rich_text: [{ type: "text", text: { content: podcast.platform } }],
+    },
+    source: { url: podcast.url },
+  }
+
+  if (podcast.show_name) {
+    properties.show_name = {
+      rich_text: [{ type: "text", text: { content: podcast.show_name } }],
+    }
+  }
+
+  const response = await fetch(`${NOTION_API_URL}/pages`, {
+    method: "POST",
+    headers: notionHeaders(accessToken),
+    body: JSON.stringify({
+      parent: { database_id: databaseId },
+      properties,
+      children: splitIntoCodeBlocks(content),
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`Notionページ作成に失敗しました: ${error}`)
+  }
+
+  const result = await response.json()
+  return result.id
+}

--- a/lib/notion/oauth.ts
+++ b/lib/notion/oauth.ts
@@ -1,0 +1,77 @@
+const NOTION_OAUTH_URL = "https://api.notion.com/v1/oauth/authorize"
+const NOTION_TOKEN_URL = "https://api.notion.com/v1/oauth/token"
+
+export function getNotionAuthUrl(state: string): string {
+  const clientId = process.env.NOTION_OAUTH_CLIENT_ID
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL
+
+  if (!clientId || !appUrl) {
+    throw new Error("Notion OAuth環境変数が設定されていません")
+  }
+
+  const redirectUri = `${appUrl}/api/auth/notion/callback`
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    owner: "user",
+    state,
+  })
+
+  return `${NOTION_OAUTH_URL}?${params.toString()}`
+}
+
+export interface NotionTokenResponse {
+  access_token: string
+  workspace_name: string
+  workspace_id: string
+  bot_id: string
+}
+
+export async function exchangeCodeForTokens(code: string): Promise<NotionTokenResponse> {
+  const clientId = process.env.NOTION_OAUTH_CLIENT_ID
+  const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL
+
+  if (!clientId || !clientSecret || !appUrl) {
+    throw new Error("Notion OAuth環境変数が設定されていません")
+  }
+
+  const redirectUri = `${appUrl}/api/auth/notion/callback`
+  const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString("base64")
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 15000)
+
+  try {
+    const response = await fetch(NOTION_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${credentials}`,
+      },
+      body: JSON.stringify({
+        code,
+        grant_type: "authorization_code",
+        redirect_uri: redirectUri,
+      }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeoutId)
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(`Notionトークン取得に失敗しました: ${error}`)
+    }
+
+    return response.json()
+  } catch (error) {
+    clearTimeout(timeoutId)
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Notionトークン取得リクエストがタイムアウトしました")
+    }
+    throw error
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,7 @@ export type Podcast = {
   watched_at: string | null
   created_at: string
   google_drive_file_created: boolean
+  notion_page_created: boolean
   show_name: string | null
   tags: string[]
   speakers: string[]

--- a/scripts/013_create_notion_settings.sql
+++ b/scripts/013_create_notion_settings.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS public.notion_settings (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL UNIQUE,
+  encrypted_access_token TEXT NOT NULL,
+  workspace_name TEXT,
+  database_id TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL
+);
+
+ALTER TABLE public.notion_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own notion settings"
+  ON public.notion_settings FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/scripts/014_add_notion_page_created.sql
+++ b/scripts/014_add_notion_page_created.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.podcasts
+ADD COLUMN IF NOT EXISTS notion_page_created BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
- OAuth認証でNotionと連携（暗号化アクセストークン管理）
- Notionデータベース自動作成（title/date/platform/source/show_name）
- 視聴中・視聴済み設定時にNotionページを自動生成
- 設定ページからの一括エクスポート機能
- 既存のGoogle Driveパターンと同様の実装

Closes #256