### PR TITLE
feat: 詳細ダイアログにGemini AI再生成ボタンを追加

### DIFF
--- a/components/add-podcast-form.tsx
+++ b/components/add-podcast-form.tsx
@@ -4,12 +4,12 @@ import { Loader2 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import type React from "react"
 import { useEffect, useRef, useState } from "react"
-import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
+import { showAIGenerateToasts } from "@/lib/ai-toast"
 import { createClient } from "@/lib/supabase/client"
 import { detectPlatform, getPriorityLabel, PLATFORM_OPTIONS, type Platform, type Priority } from "@/lib/utils"
 
@@ -151,24 +151,7 @@ export function AddPodcastForm({ userId, onSuccess, initialUrl, autoFetch }: Add
           return res.json() as Promise<{ summary?: string | null }>
         })
 
-        toast.promise(tagPromise, {
-          loading: "AIがタグ・出演者を生成中...",
-          success: "タグ・出演者の生成が完了しました",
-          error: "タグ生成に失敗しました",
-        })
-
-        if (platform === "youtube") {
-          toast.promise(
-            tagPromise.then((result) => {
-              if (!result.summary) throw new Error("文字起こしが生成されませんでした")
-            }),
-            {
-              loading: "AIがYouTube動画を文字起こし中...",
-              success: "YouTube動画の文字起こしが完了しました",
-              error: "YouTube文字起こしに失敗しました",
-            }
-          )
-        }
+        showAIGenerateToasts(tagPromise, platform)
       }
 
       console.log("[v0] Podcast追加成功、リダイレクト開始")

--- a/components/podcast-card.tsx
+++ b/components/podcast-card.tsx
@@ -36,7 +36,7 @@ type PodcastCardProps = {
     }
   ) => Promise<void>
   onChangeWatchedStatus: (id: string, newStatus: boolean) => Promise<void>
-  onRegenerateAI: (id: string) => Promise<void>
+  onRegenerateAI: (id: string) => Promise<{ summary: string | null }>
 }
 
 export function PodcastCard({

--- a/components/podcast-dialog.tsx
+++ b/components/podcast-dialog.tsx
@@ -3,7 +3,6 @@
 import { Check, ChevronDown, Copy, Loader2, Play, Sparkles, Trash2 } from "lucide-react"
 import Image from "next/image"
 import { useEffect, useState } from "react"
-import { toast } from "sonner"
 import { PodcastTags } from "@/components/podcast-tags"
 import { SimpleMarkdown } from "@/components/simple-markdown"
 import { Badge } from "@/components/ui/badge"
@@ -16,6 +15,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard"
+import { showAIGenerateToasts } from "@/lib/ai-toast"
 import type { Podcast } from "@/lib/types"
 import {
   getPlatformColor,
@@ -33,7 +33,7 @@ type PodcastDialogProps = {
   onChangePriority: (id: string, newPriority: Priority) => Promise<void>
   onStartWatching: (id: string) => Promise<void>
   onChangeWatchedStatus: (id: string, newStatus: boolean) => Promise<void>
-  onRegenerateAI: (id: string) => Promise<void>
+  onRegenerateAI: (id: string) => Promise<{ summary: string | null }>
 }
 
 const DESCRIPTION_MAX_LENGTH_MOBILE = 70
@@ -96,14 +96,8 @@ export function PodcastDialog({
 
   const handleRegenerate = () => {
     setIsRegenerating(true)
-    toast.promise(
-      onRegenerateAI(podcast.id).finally(() => setIsRegenerating(false)),
-      {
-        loading: "AIがタグ・出演者・要約を再生成中...",
-        success: "タグ・出演者・要約の再生成が完了しました",
-        error: "AI再生成に失敗しました",
-      }
-    )
+    const promise = onRegenerateAI(podcast.id).finally(() => setIsRegenerating(false))
+    showAIGenerateToasts(promise, podcast.platform, "regenerate")
   }
 
   return (

--- a/components/podcast-list-item.tsx
+++ b/components/podcast-list-item.tsx
@@ -35,7 +35,7 @@ type PodcastListItemProps = {
     }
   ) => Promise<void>
   onChangeWatchedStatus: (id: string, newStatus: boolean) => Promise<void>
-  onRegenerateAI: (id: string) => Promise<void>
+  onRegenerateAI: (id: string) => Promise<{ summary: string | null }>
 }
 
 export function PodcastListItem({

--- a/components/podcast-list.tsx
+++ b/components/podcast-list.tsx
@@ -287,6 +287,8 @@ export function PodcastList({ userId }: PodcastListProps) {
       podcasts.map((p) => (p.id === id ? { ...p, tags, speakers, summary } : p)),
       false
     )
+
+    return { tags, speakers, summary }
   }
 
   const handleUpdatePodcast = async (

--- a/lib/ai-toast.ts
+++ b/lib/ai-toast.ts
@@ -1,0 +1,30 @@
+import { toast } from "sonner"
+
+type AIGenerateResult = { summary?: string | null }
+
+export function showAIGenerateToasts(
+  promise: Promise<AIGenerateResult>,
+  platform: string | null | undefined,
+  mode: "add" | "regenerate" = "add"
+): void {
+  const verb = mode === "regenerate" ? "再生成" : "生成"
+
+  toast.promise(promise, {
+    loading: `AIがタグ・出演者を${verb}中...`,
+    success: `タグ・出演者の${verb}が完了しました`,
+    error: `タグ・出演者の${verb}に失敗しました`,
+  })
+
+  if (platform === "youtube") {
+    toast.promise(
+      promise.then((result) => {
+        if (!result.summary) throw new Error("文字起こしが生成されませんでした")
+      }),
+      {
+        loading: "AIがYouTube動画を文字起こし中...",
+        success: "YouTube動画の文字起こしが完了しました",
+        error: "YouTube文字起こしに失敗しました",
+      }
+    )
+  }
+}


### PR DESCRIPTION
Fixes #261

Gemini生成のタグ・出演者・要約をGUIからリトライできるよう、ポッドキャスト詳細ダイアログのフッターに「AI再生成」ボタンを追加。

Generated with [Claude Code](https://claude.ai/code)