### PR TITLE
feat: Notionエクスポート時にtags/speakersをDBプロパティとして設定

### DIFF
--- a/app/api/notion/create-page/route.ts
+++ b/app/api/notion/create-page/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import type { PodcastData } from "@/lib/google/drive"
-import { createNotionPage } from "@/lib/notion/notion"
+import { createNotionPage, ensureDatabaseProperties } from "@/lib/notion/notion"
 import { getNotionAuth, NotionAuthError } from "@/lib/notion/notion-auth"
 import { createClient } from "@/lib/supabase/server"
 
@@ -18,6 +18,7 @@ export async function POST(request: NextRequest) {
   try {
     const body: PodcastData = await request.json()
     const { accessToken, databaseId } = await getNotionAuth(supabase, user.id)
+    await ensureDatabaseProperties(accessToken, databaseId)
     const pageId = await createNotionPage(accessToken, databaseId, body)
 
     return NextResponse.json({ success: true, pageId })

--- a/app/api/notion/export-watched/route.ts
+++ b/app/api/notion/export-watched/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import type { PodcastData } from "@/lib/google/drive"
-import { createNotionPage } from "@/lib/notion/notion"
+import { createNotionPage, ensureDatabaseProperties } from "@/lib/notion/notion"
 import { getNotionAuth, NotionAuthError } from "@/lib/notion/notion-auth"
 import { createClient } from "@/lib/supabase/server"
 
@@ -17,6 +17,7 @@ export async function POST(_request: NextRequest) {
 
   try {
     const { accessToken, databaseId } = await getNotionAuth(supabase, user.id)
+    await ensureDatabaseProperties(accessToken, databaseId)
 
     // 視聴済みかつページ未作成のPodcastを取得
     const { data: podcasts, error: podcastsError } = await supabase


### PR DESCRIPTION
Closes #263

## 変更内容

- `createNotionDatabase()` にtags/speakersのmulti_selectプロパティを追加
- `ensureDatabaseProperties()` を新規作成（既存DBへのプロパティ自動追加）
- `createNotionPage()` でtags/speakersをmulti_selectプロパティとして設定
- create-page/export-watchedの各API routeにensure呼び出しを追加

Generated with [Claude Code](https://claude.ai/code)