### PR TITLE
chore: pnpmにクールダウン期間(7日)を設定

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
- `pnpm-workspace.yaml` に `minimumReleaseAge: 10080`（7日 = 10,080分）を追加
- 公開直後のパッケージのインストールを防止し、サプライチェーン攻撃のリスクを軽減
- Dependabotのクールダウン期間（7日）と同じポリシーをpnpm側でも適用

## Background
npm等のレジストリでは、悪意あるパッケージが公開されてから検出・削除されるまでにタイムラグがあります。`minimumReleaseAge` を設定することで、公開から一定期間が経過していないバージョンのインストールをブロックし、サプライチェーンセキュリティを強化します。

## Test plan
- [ ] `pnpm install` が正常に動作することを確認
- [ ] 新規パッケージ追加時にクールダウンが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)