### PR TITLE
chore: サードパーティactionのSHAピン留めと.env.example再構成

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,52 @@
-# Supabase
+# =============================================================================
+# 必須（Required）— これらが揃わないと本番アプリは動作しない
+# =============================================================================
+
+# Supabase（DB / Auth）
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 
-# Gemini API
-GEMINI_API_KEY=your-gemini-api-key
+# アプリのベースURL（OAuthコールバック・LINE webhookで使用）
+NEXT_PUBLIC_APP_URL=https://your-app-url
 
-# LINE Messaging API
-LINE_CHANNEL_SECRET=your-line-channel-secret
-LINE_CHANNEL_ACCESS_TOKEN=your-line-channel-access-token
-
-# Google OAuth & Drive
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
-
-# 暗号化キー（32バイトの16進数文字列）
+# 暗号化キー（GoogleドライブとNotionのリフレッシュトークン保存用）
+# 32バイトの16進数文字列。`node scripts/generate-encryption-key.mjs` で生成
 ENCRYPTION_KEY=your-encryption-key
 
-# LangSmith トレーシング（オプション）
+# Gemini API（タグ生成・要約）
+GEMINI_API_KEY=your-gemini-api-key
+
+# Google OAuth（Googleドライブ連携）
+GOOGLE_OAUTH_CLIENT_ID=your-google-oauth-client-id
+GOOGLE_OAUTH_CLIENT_SECRET=your-google-oauth-client-secret
+
+# Notion OAuth（Notion連携）
+NOTION_OAUTH_CLIENT_ID=your-notion-oauth-client-id
+NOTION_OAUTH_CLIENT_SECRET=your-notion-oauth-client-secret
+
+# LINE Messaging API（LINE webhook経由でURL登録）
+LINE_MESSAGING_CHANNEL_SECRET=your-line-channel-secret
+LINE_MESSAGING_CHANNEL_ACCESS_TOKEN=your-line-channel-access-token
+
+# =============================================================================
+# オプション（Optional）— 未設定でもアプリは動作する
+# =============================================================================
+
+# メタデータ取得API（未設定時は oEmbed 等にフォールバック）
+YOUTUBE_API_KEY=your-youtube-api-key
+SPOTIFY_CLIENT_ID=your-spotify-client-id
+SPOTIFY_CLIENT_SECRET=your-spotify-client-secret
+
+# LangSmith トレーシング
+# LANGCHAIN_TRACING_V2=true のときのみ有効化される
 LANGCHAIN_TRACING_V2=false
 LANGCHAIN_API_KEY=your-langsmith-api-key
-LANGSMITH_PROJECT=your-project-name
+LANGSMITH_PROJECT=your-langsmith-project-name
+
+# =============================================================================
+# ローカル開発のみ（Local development only）
+# =============================================================================
+
+# サインアップ後のリダイレクト先（未設定時は window.location.origin/podcasts）
+NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL=http://localhost:3000/podcasts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.3
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           version: 10
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: 変更検知
         id: changes
-        uses: dorny/paths-filter@v4.0.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             github:


### PR DESCRIPTION
## Summary
- **CI ワークフロー**: GitHub Advanced Security の `actions/unpinned-tag` アラート（Alert #50）を解消
  - `pnpm/action-setup@v6.0.3` を commit SHA `903f9c1` にピン留め
  - 既存アラートには出ていなかった `dorny/paths-filter@v4.0.1` も同じくサードパーティのため commit SHA `fbd0ab8` にピン留め
  - バージョンタグは行末コメントで保持し、Dependabot の自動 SHA 更新を維持
  - GitHub 公式（`actions/*`, `github/*`）は CodeQL の検出対象外のため変更なし
- **`.env.example`**: 必須 / オプション / ローカル開発のセクションに再構成
  - Notion OAuth、YOUTUBE/SPOTIFY API キー等の不足項目を追記
  - `LINE_CHANNEL_SECRET` → `LINE_MESSAGING_CHANNEL_SECRET` 等、実装と乖離していたキー名を修正

## Test plan
- [ ] CodeQL ワークフローがパスし、`actions/unpinned-tag` アラートが消えること
- [ ] CI ワークフロー（pnpm セットアップ）が問題なく動作すること
- [ ] `.env.example` の各項目が現行コードの参照名と一致していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)