### PR TITLE
chore: add Socket Firewall to dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,15 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: "pnpm"
+
+      - name: Setup Socket Firewall
+        uses: socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1
+        with:
+          mode: firewall
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
 
       - name: Run Biome CI (lint + format)
         run: pnpm run ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ PodQueueは、ポッドキャストをプラットフォーム横断で一元管
 1. 実装計画を立てる。セッション内ですでにプランニングが終わっている場合は不要
 2. コードを実装する
 3. テストコードを実装する
-4. pnpm install で依存関係を更新する
+4. `sfw pnpm install` でSocket Firewallを通して依存関係を更新する
 5. pnpm run test でテストを行う
 6. pnpm run check を実行し、lint/format/typecheck/knipが通ることを確認する
 7. ドキュメント(AGENTS.md,README.md)を更新する
@@ -61,6 +61,7 @@ PodQueueは、ポッドキャストをプラットフォーム横断で一元管
 
 ```bash
 pnpm run dev          # 開発サーバー起動
+sfw pnpm install      # 依存関係インストール（Socket Firewall経由）
 pnpm run build        # ビルド
 pnpm run test         # テスト実行（vitest run）
 pnpm run test:watch   # テスト監視モード

--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ node scripts/generate-encryption-key.mjs
 
 ## 開発
 
+サプライチェーン攻撃対策として [Socket Firewall Free](https://docs.socket.dev/docs/socket-firewall-free) を導入しています。依存関係を取得するときは `sfw` 経由で実行します。
+
 ```bash
+# 依存関係インストール
+sfw pnpm install
+
 # 開発サーバー起動
 pnpm run dev
 


### PR DESCRIPTION
## Summary
- Add Socket Firewall setup to GitHub Actions dependency install steps.
- Route local documented dependency installs through `sfw`.

## Scope
This PR intentionally covers the easy install-time protection points we control directly:
- GitHub Actions `pnpm install`
- Local developer install commands

Production platform-managed dependency installation is out of scope for this PR. Vercel's production build install command may still run outside `sfw` unless configured separately in Vercel project settings or a future `vercel.json`. PR-level Socket/GitHub diagnostics will cover the broader review path separately.

## Tests
- `git diff --check`