### PR TITLE
chore: Dependabotポリシーを統一

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
           - "*"
     cooldown:
       default-days: 7
-      semver-major-days: 30
+      semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
     open-pull-requests-limit: 10


### PR DESCRIPTION
## 変更内容

- npmのmajorクールダウンを30日から14日に変更

## 理由

共通リポジトリポリシーのmajor 14日に合わせるため。

## 確認

- `pnpm config get minimumReleaseAge --location=project` → `10080`
- `git diff --check` 成功