### PR TITLE
docs: 指示ファイルとスキルの同期をhookとCIで検証する

### DIFF
--- a/.agents/skills/add-package/SKILL.md
+++ b/.agents/skills/add-package/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: add-package
+description: パッケージを追加する際に使用します。開発用と、プロダクト用途問わずこれを使います。
+---
+
+# パッケージ追加スキル
+
+このスキルは、pnpmを使ってプロジェクトにパッケージを追加する正しい方法を提供します。
+
+## Instructions
+
+1. `pnpm add <package-name>` コマンドでパッケージを追加する
+   - 通常の依存パッケージ: `pnpm add <package-name>`
+   - 開発用依存パッケージ: `pnpm add -D <package-name>`
+2. パッケージ追加後、`package.json` にパッケージが追加されていることを確認する
+3. `pnpm-lock.yaml` が更新されていることを確認する
+
+## 注意事項
+
+⚠️ **package.jsonを直接編集しないでください**
+
+パッケージを追加する際は、必ず `pnpm add` コマンドを使用してください。package.jsonを直接編集すると、pnpm-lock.yamlが更新されず、依存関係の整合性が失われます。

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# AI向け指示ファイルとスキルフォルダの同期を検証する。
+# ローカルではpre-commit hookとして、CIでは同じスクリプトを直接実行する。
+# Git以外の外部コマンドには依存しない。
+
+set -u
+
+status=0
+
+agents_oid=$(git rev-parse --verify :AGENTS.md 2>/dev/null || :)
+claude_oid=$(git rev-parse --verify :CLAUDE.md 2>/dev/null || :)
+
+if [ -z "$agents_oid" ] || [ -z "$claude_oid" ]; then
+  echo "同期エラー: AGENTS.md と CLAUDE.md の両方が必要です。" >&2
+  status=1
+elif [ "$agents_oid" != "$claude_oid" ]; then
+  echo "同期エラー: AGENTS.md と CLAUDE.md の内容が一致しません。" >&2
+  status=1
+fi
+
+tree=$(git write-tree) || {
+  echo "同期チェック用のtreeを作成できませんでした。" >&2
+  exit 2
+}
+
+agents_skills=$(git rev-parse --verify "$tree:.agents/skills" 2>/dev/null || :)
+claude_skills=$(git rev-parse --verify "$tree:.claude/skills" 2>/dev/null || :)
+
+if [ "$agents_skills" != "$claude_skills" ]; then
+  echo "同期エラー: .agents/skills と .claude/skills の内容が一致しません。" >&2
+  status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+  exit 0
+fi
+
+echo "両側を同じ内容に揃えてから、もう一度コミットしてください。" >&2
+git diff --cached --name-status -- AGENTS.md CLAUDE.md .agents/skills .claude/skills >&2
+exit 1

--- a/.github/workflows/agent-docs-sync.yml
+++ b/.github/workflows/agent-docs-sync.yml
@@ -1,0 +1,17 @@
+name: agent-docs-sync
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: 指示ファイルとスキルの同期を検証
+        run: sh .githooks/pre-commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,6 @@ LANGSMITH_PROJECT
 
 ## 指示ファイルの同期
 
-`AGENTS.md` と `CLAUDE.md`、`.agents/skills` と `.claude/skills` は、それぞれ同じ内容の別実体として管理する。シンボリックリンクにはしない（Windowsで `git worktree` が失敗するため）。片方だけを変更せず、両方を同じ内容に揃えてコミットする。
+`AGENTS.md` と `CLAUDE.md`、`.agents/skills` と `.claude/skills` は同じ内容の別実体。片方を変更したら、もう一方も同じ内容に揃える。
 
-クローン後に `git config core.hooksPath .githooks` を実行し、コミット時の検証を有効にする。CIでも同じ検証を行う。
+クローン後に `git config core.hooksPath .githooks` を実行する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+# PodQueue
 
 ## 言語設定
 
@@ -57,7 +57,7 @@ PodQueueは、ポッドキャストをプラットフォーム横断で一元管
 4. `sfw pnpm install` でSocket Firewallを通して依存関係を更新する
 5. pnpm run test でテストを行う
 6. pnpm run check を実行し、lint/format/typecheck/knipが通ることを確認する
-7. ドキュメント(AGENTS.md,README.md)を更新する
+7. ドキュメント(AGENTS.md/CLAUDE.md, README.md)を更新する
 
 ## コマンド
 
@@ -125,3 +125,9 @@ NEXT_PUBLIC_APP_URL         # アプリのベースURL
 LANGCHAIN_TRACING_V2        # "true"で有効化
 LANGSMITH_PROJECT
 ```
+
+## 指示ファイルの同期
+
+`AGENTS.md` と `CLAUDE.md`、`.agents/skills` と `.claude/skills` は、それぞれ同じ内容の別実体として管理する。シンボリックリンクにはしない（Windowsで `git worktree` が失敗するため）。片方だけを変更せず、両方を同じ内容に揃えてコミットする。
+
+クローン後に `git config core.hooksPath .githooks` を実行すると、コミット時に一致を検証する。CIでも同じ検証を行う。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,4 +130,4 @@ LANGSMITH_PROJECT
 
 `AGENTS.md` と `CLAUDE.md`、`.agents/skills` と `.claude/skills` は、それぞれ同じ内容の別実体として管理する。シンボリックリンクにはしない（Windowsで `git worktree` が失敗するため）。片方だけを変更せず、両方を同じ内容に揃えてコミットする。
 
-クローン後に `git config core.hooksPath .githooks` を実行すると、コミット時に一致を検証する。CIでも同じ検証を行う。
+クローン後に `git config core.hooksPath .githooks` を実行し、コミット時の検証を有効にする。CIでも同じ検証を行う。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,133 @@
-AGENTS.md
+# PodQueue
+
+## 言語設定
+
+常に日本語で回答してください。
+
+## サービスレベル
+
+少人数向けの個人開発アプリだが、ポートフォリオとして第三者に見せることを想定している。コードの読みやすさや設計の妥当性は意識しつつ、過度なエンジニアリングは避ける
+
+## 実装方針
+
+- 過度に高品質な実装は不要。
+- 必要な要件をよく考え最小のコードで要件を達成することが望ましい。
+- 開発者は1人。自分が使う上で最低限のエラーハンドリングやセキュリティ対応を行う
+- 病的なまでの正確さよりも、常にシンプルさを優先すること。
+- YAGNI、KISS、DRYを徹底せよ。
+- サイクロマチック複雑度（循環的複雑度）を増大させずに済む場合を除き、後方互換性のためのシムやフォールバックパスは設けないこと。
+
+## テスト方針
+
+- カバレッジだけを追い求めず、開発者が認知・管理できる範囲に留める
+- 正常系を中心にテストを実装
+- 異常系は必要最低限のものに限定
+- 1人開発のため、過度な品質は追求しない
+- 外部リソース中心でモック中心になるテストは見送る
+- テストフレームワーク: Vitest + Testing Library + happy-dom
+
+## アプリ概要
+
+PodQueueは、ポッドキャストをプラットフォーム横断で一元管理するためのWebアプリケーション。YouTube、Spotify、NewsPicks等のコンテンツを「あとで聴く」リストとして管理する。
+
+## ディレクトリ構成
+
+- `app/` — Next.js App Routerのページ・APIルート
+  - `app/api/` — APIエンドポイント（LINE webhook、Google OAuth、Google Drive等）
+  - `app/podcasts/` — ポッドキャスト一覧・詳細ページ
+  - `app/settings/` — 設定ページ
+  - `app/samples/` — サンプルポッドキャストページ
+- `components/` — UIコンポーネント（`components/ui/` はshadcn/ui自動生成）
+- `lib/` — ビジネスロジック・ユーティリティ
+  - `lib/supabase/` — Supabaseクライアント（client/server/admin）
+  - `lib/gemini/` — Gemini AI連携（タグ生成、要約、embedding生成）
+  - `lib/google/` — Google Drive/OAuth連携
+  - `lib/metadata/` — URLからのメタデータ取得
+  - `lib/line/` — LINE Messaging API連携（reply/push）
+  - `lib/youtube/` — YouTube Data APIでのチャンネル新着取得
+  - `lib/recommendation/` — レコメンド対象の選定ロジック
+- `hooks/` — カスタムReact hooks
+- `scripts/` — DBマイグレーション・ユーティリティスクリプト
+
+## 実装手順
+
+1. 実装計画を立てる。セッション内ですでにプランニングが終わっている場合は不要
+2. コードを実装する
+3. テストコードを実装する
+4. `sfw pnpm install` でSocket Firewallを通して依存関係を更新する
+5. pnpm run test でテストを行う
+6. pnpm run check を実行し、lint/format/typecheck/knipが通ることを確認する
+7. ドキュメント(AGENTS.md/CLAUDE.md, README.md)を更新する
+
+## コマンド
+
+```bash
+pnpm run dev          # 開発サーバー起動
+sfw pnpm install      # 依存関係インストール（Socket Firewall経由）
+pnpm run build        # ビルド
+pnpm run test         # テスト実行（vitest run）
+pnpm run test:watch   # テスト監視モード
+pnpm run check        # formatting + linting + typecheck + knip（CI前に必ず実行）
+pnpm run lint         # Biome lint（--write付き）
+pnpm run format       # Biome format（--write付き）
+pnpm run typecheck    # tsc --noEmit
+pnpm run knip         # 未使用コード検出
+```
+
+## 技術スタック
+
+- **フレームワーク**: Next.js 16 (App Router), React 19
+- **UI**: shadcn/ui (new-york), Tailwind CSS 4, Radix UI, sonner
+- **DB/認証**: Supabase (PostgreSQL + Auth)
+- **AI**: Vercel AI SDK + Google Gemini
+- **Linter/Formatter**: Biome（ESLint/Prettierは不使用）
+- **テスト**: Vitest + Testing Library + happy-dom
+- **パスエイリアス**: `@/*` でルートからのインポート
+
+## コードスタイル
+
+- Biomeで統一（`biome.json`参照）
+- インデント: スペース2、行幅: 110
+- ダブルクォート、セミコロンなし（ASI）、末尾カンマES5
+- `components/ui/` はshadcn/ui自動生成のためlint対象外
+
+## 環境変数
+
+```
+# 必須
+NEXT_PUBLIC_SUPABASE_URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY
+SUPABASE_SERVICE_ROLE_KEY
+
+# Google Drive連携
+GOOGLE_OAUTH_CLIENT_ID
+GOOGLE_OAUTH_CLIENT_SECRET
+ENCRYPTION_KEY              # リフレッシュトークン暗号化用（node scripts/generate-encryption-key.mjsで生成）
+
+# AI機能
+GEMINI_API_KEY
+
+# YouTube Data API（メタデータ取得・レコメンドの新着取得）
+YOUTUBE_API_KEY
+
+# LINE連携
+LINE_MESSAGING_CHANNEL_SECRET
+LINE_MESSAGING_CHANNEL_ACCESS_TOKEN
+
+# レコメンド（Vercel Cron）
+CRON_SECRET                 # /api/cron/recommend の認証用
+RECOMMEND_SCORE_THRESHOLD   # オプション、類似度閾値（デフォルト0.5）
+
+# 共通
+NEXT_PUBLIC_APP_URL         # アプリのベースURL
+
+# オプション（Observability）
+LANGCHAIN_TRACING_V2        # "true"で有効化
+LANGSMITH_PROJECT
+```
+
+## 指示ファイルの同期
+
+`AGENTS.md` と `CLAUDE.md`、`.agents/skills` と `.claude/skills` は、それぞれ同じ内容の別実体として管理する。シンボリックリンクにはしない（Windowsで `git worktree` が失敗するため）。片方だけを変更せず、両方を同じ内容に揃えてコミットする。
+
+クローン後に `git config core.hooksPath .githooks` を実行すると、コミット時に一致を検証する。CIでも同じ検証を行う。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,6 @@ LANGSMITH_PROJECT
 
 ## 指示ファイルの同期
 
-`AGENTS.md` と `CLAUDE.md`、`.agents/skills` と `.claude/skills` は、それぞれ同じ内容の別実体として管理する。シンボリックリンクにはしない（Windowsで `git worktree` が失敗するため）。片方だけを変更せず、両方を同じ内容に揃えてコミットする。
+`AGENTS.md` と `CLAUDE.md`、`.agents/skills` と `.claude/skills` は同じ内容の別実体。片方を変更したら、もう一方も同じ内容に揃える。
 
-クローン後に `git config core.hooksPath .githooks` を実行し、コミット時の検証を有効にする。CIでも同じ検証を行う。
+クローン後に `git config core.hooksPath .githooks` を実行する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,4 +130,4 @@ LANGSMITH_PROJECT
 
 `AGENTS.md` と `CLAUDE.md`、`.agents/skills` と `.claude/skills` は、それぞれ同じ内容の別実体として管理する。シンボリックリンクにはしない（Windowsで `git worktree` が失敗するため）。片方だけを変更せず、両方を同じ内容に揃えてコミットする。
 
-クローン後に `git config core.hooksPath .githooks` を実行すると、コミット時に一致を検証する。CIでも同じ検証を行う。
+クローン後に `git config core.hooksPath .githooks` を実行し、コミット時の検証を有効にする。CIでも同じ検証を行う。


### PR DESCRIPTION
`AGENTS.md` と `CLAUDE.md` をシンボリックリンクではなく同じ内容の別ファイルとして管理し、ズレをhookとCIで検知するようにします。

## 背景

Windowsではシンボリックリンクの作成に管理者権限が必要で、`git worktree add` が失敗することがありました。複製を許容して同期検証で担保する方式に切り替えます。

## 変更内容

- `AGENTS.md` / `CLAUDE.md` を実体ファイル化し、内容を一致させた
- `.githooks/pre-commit` を追加。ステージ済みの指示ファイルとスキルフォルダの一致を検証する（Git以外の外部コマンドに依存しない）
- `.github/workflows/agent-docs-sync.yml` を追加。同じhookスクリプトをCIで実行するので、検証ロジックは1箇所だけ
- 指示ファイル自体に同期方針を記載した

## 有効化

クローン側で一度だけ実行してください。

```
git config core.hooksPath .githooks
```

未設定の環境から入ったコミットはCIが検知します。
