### PR TITLE
Deny unnecessary dependency build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
+allowBuilds:
+  esbuild: false
+  sharp: false
 minimumReleaseAge: 10080


### PR DESCRIPTION
## 概要

- `pnpm-workspace.yaml` で `esbuild` と `sharp` の依存ビルドスクリプトを明示的に拒否
- pnpm 11の未審査ビルドエラーを、postinstallを許可せず解消

## 背景

Windows側のpnpm 11では、未審査の依存ビルドスクリプトがあると `ERR_PNPM_IGNORED_BUILDS` で終了していた。両パッケージはinstall scriptなしでも現在のWindows環境で正常動作することを確認したため、最小権限として `false` を記録する。

## 影響

依存パッケージのinstall/postinstallは実行しないまま、通常の開発コマンドが実行可能になる。

## 検証

- `sfw pnpm install`
- `pnpm run test`（229件成功）
- `pnpm run check`
- `pnpm run build`
- `pnpm run dev`（`/auth/login` がHTTP 200）