### PR TITLE
fix: レコメンド通知をカルーセル形式の1メッセージにまとめる

### DIFF
--- a/app/api/cron/recommend/route.ts
+++ b/app/api/cron/recommend/route.ts
@@ -1,13 +1,13 @@
 import { cosineSimilarity } from "ai"
 import { NextResponse } from "next/server"
 import { buildEmbeddingInput, generateEmbeddings } from "@/lib/gemini/generate-embedding"
-import { buildRecommendationFlexMessage } from "@/lib/line/flex-message"
+import { buildRecommendationCarouselMessage } from "@/lib/line/flex-message"
 import { pushMessage } from "@/lib/line/push"
 import { latestPublishedAt, pickRecommendations, selectNewVideos } from "@/lib/recommendation/select"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { fetchLatestVideos, type YoutubeVideo } from "@/lib/youtube/fetch-latest-videos"
 
-// 1回の通知で送る最大件数（LINE pushは1リクエスト5メッセージまで）
+// 1回の通知で送る最大件数（カルーセル1メッセージにまとめて送信、LINE仕様上は10件まで可能）
 const MAX_RECOMMENDATIONS = 3
 
 type Channel = {
@@ -130,18 +130,17 @@ async function processUser(
 
     const picks = pickRecommendations(scored, threshold, MAX_RECOMMENDATIONS)
     if (picks.length > 0) {
-      await pushMessage(
-        lineLink.line_user_id,
-        picks.map((video) =>
-          buildRecommendationFlexMessage({
+      await pushMessage(lineLink.line_user_id, [
+        buildRecommendationCarouselMessage(
+          picks.map((video) => ({
             title: video.title,
             channelLabel: video.channelLabel,
             score: video.score,
             videoUrl: video.url,
             thumbnailUrl: video.thumbnailUrl,
-          })
-        )
-      )
+          }))
+        ),
+      ])
       notified = picks.length
     }
   }

--- a/lib/line/__tests__/flex-message.test.ts
+++ b/lib/line/__tests__/flex-message.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
-import { buildRecommendationFlexMessage } from "../flex-message"
+import { buildRecommendationCarouselMessage } from "../flex-message"
 
-describe("buildRecommendationFlexMessage", () => {
+describe("buildRecommendationCarouselMessage", () => {
   const params = {
     title: "テスト動画",
     channelLabel: "テストチャンネル",
@@ -11,10 +11,12 @@ describe("buildRecommendationFlexMessage", () => {
   }
 
   it("footerに動画を見るボタンとPodQueueに登録ボタンが含まれる", () => {
-    const message = buildRecommendationFlexMessage(params)
-    if (message.type !== "flex") throw new Error("flex message expected")
+    const message = buildRecommendationCarouselMessage([params])
+    if (message.type !== "flex" || message.contents.type !== "carousel") {
+      throw new Error("flex carousel message expected")
+    }
 
-    expect(message.contents.footer?.contents).toEqual([
+    expect(message.contents.contents[0].footer?.contents).toEqual([
       {
         type: "button",
         style: "primary",
@@ -28,5 +30,16 @@ describe("buildRecommendationFlexMessage", () => {
         action: { type: "message", label: "PodQueueに登録", text: params.videoUrl },
       },
     ])
+  })
+
+  it("複数件を1つのcarouselメッセージにまとめる", () => {
+    const params2 = { ...params, title: "テスト動画2", videoUrl: "https://www.youtube.com/watch?v=def456" }
+    const message = buildRecommendationCarouselMessage([params, params2])
+    if (message.type !== "flex" || message.contents.type !== "carousel") {
+      throw new Error("flex carousel message expected")
+    }
+
+    expect(message.contents.contents).toHaveLength(2)
+    expect(message.altText).toBe("おすすめの新着動画が2件あります")
   })
 })

--- a/lib/line/flex-message.ts
+++ b/lib/line/flex-message.ts
@@ -105,10 +105,10 @@ type RecommendationMessageParams = {
 }
 
 /**
- * レコメンド通知のFlex Messageを生成
+ * レコメンド通知1件分のbubbleを生成
  * スコアは閾値チューニングのため通知に表示する
  */
-export function buildRecommendationFlexMessage(params: RecommendationMessageParams): LineMessage {
+function buildRecommendationBubble(params: RecommendationMessageParams): FlexBubble {
   const title = truncate(params.title, 50)
 
   const bubble: FlexBubble = {
@@ -182,10 +182,24 @@ export function buildRecommendationFlexMessage(params: RecommendationMessagePara
     }
   }
 
+  return bubble
+}
+
+/**
+ * 複数のレコメンドを1件のカルーセルFlex Messageにまとめて生成
+ * 個別メッセージで送ると複数投稿になり見づらいため、スワイプ形式の1メッセージにまとめる
+ */
+export function buildRecommendationCarouselMessage(items: RecommendationMessageParams[]): LineMessage {
+  const bubbles = items.map(buildRecommendationBubble)
+  const altText =
+    items.length === 1
+      ? `おすすめの新着動画: ${truncate(items[0].title, 50)}`
+      : `おすすめの新着動画が${items.length}件あります`
+
   return {
     type: "flex",
-    altText: `おすすめの新着動画: ${title}`,
-    contents: bubble,
+    altText,
+    contents: { type: "carousel", contents: bubbles },
   }
 }
 

--- a/lib/line/reply.ts
+++ b/lib/line/reply.ts
@@ -4,13 +4,22 @@
 
 export type LineMessage =
   | { type: "text"; text: string }
-  | { type: "flex"; altText: string; contents: FlexBubble }
+  | { type: "flex"; altText: string; contents: FlexBubble | FlexCarousel }
 
 export type FlexBubble = {
   type: "bubble"
   hero?: FlexImage
   body?: FlexBox
   footer?: FlexBox
+}
+
+/**
+ * 複数のbubbleをスワイプ形式の1メッセージにまとめるコンテナ
+ * https://developers.line.biz/ja/reference/messaging-api/#f-carousel
+ */
+export type FlexCarousel = {
+  type: "carousel"
+  contents: FlexBubble[]
 }
 
 export type FlexImage = {


### PR DESCRIPTION
## Summary
- レコメンド通知が複数件ある場合、これまでは動画ごとに別々のFlex Messageとして送信していたため、LINEのトーク画面で複数投稿が連続して見づらかった
- LINE Flex Messageの`carousel`コンテナを使い、複数件を1つのメッセージにまとめてスワイプ表示できるようにした

## Changes
- `lib/line/reply.ts`: `FlexCarousel`型を追加し、`LineMessage`の`flex`が`FlexBubble | FlexCarousel`を受け取れるように変更
- `lib/line/flex-message.ts`: `buildRecommendationFlexMessage`を`buildRecommendationCarouselMessage`に置き換え。複数件のレコメンドを1つのcarouselメッセージにまとめる
- `app/api/cron/recommend/route.ts`: `pushMessage`の呼び出しを複数メッセージ配列送信から、単一のcarouselメッセージ送信に変更

## Test plan
- [x] `vitest run` で既存テスト230件が通過することを確認
- [x] `tsc --noEmit` / biome check / knip でエラーがないことを確認
- [ ] 実際にLINEでレコメンド通知を受け取り、カルーセルとしてスワイプ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fS6oXiJFib3PvHGDn35yn