### PR TITLE
レコメンド用embeddingの入力を改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ YouTube / Spotify / NewsPicks などのURLを同じリストで管理し、優�
 - **LINE連携** - LINEにURLを送信するだけでPodcastを自動登録（設定画面からLINE User IDを連携）
 - **Google Drive連携** - ポッドキャストを視聴中に設定した際、Google Driveへマークダウンファイル（YAMLフロントマター形式）を自動生成し、視聴後の学びを記録可能（リフレッシュトークンはAES-256-GCMで暗号化保存）
 - **タグ自動生成** - Gemini APIを使用してポッドキャストのタイトル・説明から検索用タグを自動生成（6〜12個）
-- **新着動画レコメンド** - 登録ポッドキャストのembedding（Gemini embeddingモデル + pgvector）から興味プロファイルを生成し、登録したYouTubeチャンネルの新着動画を日次でスコアリング。類似度が閾値を超えた動画をLINEで通知。通知の「PodQueueに登録」ボタンからワンタップで聞きたいリストに追加可能。ショート動画（60秒以下）はレコメンド対象から除外
+- **新着動画レコメンド** - 視聴中・視聴済みポッドキャストのembedding（Gemini embeddingモデル + pgvector）から興味プロファイルを生成し、登録したYouTubeチャンネルの新着動画を日次でスコアリング。類似度が閾値を超えた動画をLINEで通知。通知の「PodQueueに登録」ボタンからワンタップで聞きたいリストに追加可能。ショート動画（60秒以下）はレコメンド対象から除外
 
 ## サンプルポッドキャスト
 
@@ -148,6 +148,16 @@ pnpm run knip
 
 # チェック（formatting + linting + typecheck + knip）
 pnpm run check
+```
+
+### レコメンド用embeddingの再生成
+
+ベクトル入力は、semantic similarity用途のprefix、タイトル、URL除去後の説明先頭500文字で構成します。
+入力仕様を変更した場合は、`NEXT_PUBLIC_SUPABASE_URL`、`SUPABASE_SERVICE_ROLE_KEY`、`GEMINI_API_KEY`
+を設定して既存データを全件再生成します。
+
+```bash
+pnpm exec tsx scripts/backfill-embeddings.ts --force
 ```
 
 ## ライセンス

--- a/app/api/cron/recommend/route.ts
+++ b/app/api/cron/recommend/route.ts
@@ -67,7 +67,7 @@ async function processUser(
   channels: Channel[],
   threshold: number
 ): Promise<number> {
-  // 興味プロファイル（登録済みポッドキャストのembedding平均）をDB側で計算
+  // 興味プロファイル（視聴中・視聴済みポッドキャストのembedding平均）をDB側で計算
   const { data: profileData, error: profileError } = await supabase.rpc("get_profile_embedding", {
     p_user_id: userId,
   })

--- a/lib/gemini/__tests__/generate-embedding.test.ts
+++ b/lib/gemini/__tests__/generate-embedding.test.ts
@@ -2,20 +2,36 @@ import { describe, expect, it } from "vitest"
 import { buildEmbeddingInput } from "../generate-embedding"
 
 describe("buildEmbeddingInput", () => {
-  it("タイトルと説明を改行で結合する", () => {
-    expect(buildEmbeddingInput("タイトル", "説明文")).toBe("タイトル\n説明文")
+  it("semantic similarity用の形式でタイトルと説明を組み立てる", () => {
+    expect(buildEmbeddingInput("タイトル", "説明文")).toBe(
+      "task: sentence similarity | query: title: タイトル | text: 説明文"
+    )
   })
 
   it("説明からURLを除去する", () => {
     const result = buildEmbeddingInput("タイトル", "説明 https://example.com/foo の続き")
-    expect(result).toBe("タイトル\n説明 の続き")
+    expect(result).toBe("task: sentence similarity | query: title: タイトル | text: 説明 の続き")
+  })
+
+  it("説明は先頭500文字に制限する", () => {
+    const result = buildEmbeddingInput("タイトル", "あ".repeat(501))
+    expect(result).toBe(`task: sentence similarity | query: title: タイトル | text: ${"あ".repeat(500)}`)
+  })
+
+  it("絵文字を途中で分割せず500文字に制限する", () => {
+    const result = buildEmbeddingInput("タイトル", "🎧".repeat(501))
+    expect(result).toBe(`task: sentence similarity | query: title: タイトル | text: ${"🎧".repeat(500)}`)
   })
 
   it("説明がnullの場合はタイトルのみ返す", () => {
-    expect(buildEmbeddingInput("タイトル", null)).toBe("タイトル")
+    expect(buildEmbeddingInput("タイトル", null)).toBe("task: sentence similarity | query: title: タイトル")
   })
 
   it("タイトルがnullの場合は説明のみ返す", () => {
-    expect(buildEmbeddingInput(null, "説明文")).toBe("説明文")
+    expect(buildEmbeddingInput(null, "説明文")).toBe("task: sentence similarity | query: text: 説明文")
+  })
+
+  it("タイトルと説明が空の場合は空文字を返す", () => {
+    expect(buildEmbeddingInput(" ", null)).toBe("")
   })
 })

--- a/lib/gemini/generate-embedding.ts
+++ b/lib/gemini/generate-embedding.ts
@@ -9,13 +9,30 @@ const EMBEDDING_DIMENSIONS = 768
 /** マルチモーダル対応の現行モデル。指定次元への切り詰め時もAPI側で正規化される */
 const EMBEDDING_MODEL = "gemini-embedding-2"
 
+/** 説明文後半の宣伝・リンク集などが意味を薄めないよう、先頭部分だけを使う */
+const DESCRIPTION_MAX_CHARACTERS = 500
+
+/** Gemini Embedding 2ではtaskTypeの代わりに入力へ用途を明記する */
+const SEMANTIC_SIMILARITY_PREFIX = "task: sentence similarity | query:"
+
+function truncateCharacters(text: string, maxCharacters: number): string {
+  return Array.from(text).slice(0, maxCharacters).join("").trim()
+}
+
 /**
  * embedding入力テキストを組み立てる
  * プロファイル側（登録済みポッドキャスト）と候補側（YouTube新着）で同じ形式に揃える
  */
 export function buildEmbeddingInput(title: string | null, description: string | null): string {
-  const parts = [title?.trim(), removeUrls(description || "")].filter(Boolean)
-  return parts.join("\n")
+  const normalizedTitle = title?.trim() || ""
+  const normalizedDescription = truncateCharacters(removeUrls(description || ""), DESCRIPTION_MAX_CHARACTERS)
+  const fields = [
+    normalizedTitle && `title: ${normalizedTitle}`,
+    normalizedDescription && `text: ${normalizedDescription}`,
+  ].filter(Boolean)
+
+  if (fields.length === 0) return ""
+  return `${SEMANTIC_SIMILARITY_PREFIX} ${fields.join(" | ")}`
 }
 
 /**
@@ -47,6 +64,7 @@ export async function generateEmbeddings(texts: string[]): Promise<number[][]> {
  * ポッドキャスト追加時のメタデータ生成フローから利用される
  */
 export async function generateEmbedding(text: string): Promise<number[] | null> {
+  if (!text.trim()) return null
   if (!getGeminiApiKey("embedding generation")) return null
 
   try {

--- a/scripts/017_exclude_unwatched_from_recommendations.sql
+++ b/scripts/017_exclude_unwatched_from_recommendations.sql
@@ -1,0 +1,14 @@
+-- 興味プロファイルから未視聴ポッドキャストを除外する
+-- 保存しただけのコンテンツではなく、実際に視聴を始めたコンテンツを興味の根拠にする
+
+create or replace function public.get_profile_embedding(p_user_id uuid)
+returns vector(768)
+language sql
+stable
+as $$
+  select avg(embedding)::vector(768)
+  from public.podcasts
+  where user_id = p_user_id
+    and embedding is not null
+    and status in ('watching', 'watched')
+$$;

--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -8,11 +8,13 @@
  *      - NEXT_PUBLIC_SUPABASE_URL
  *      - SUPABASE_SERVICE_ROLE_KEY（RLSバイパス用）
  *      - GEMINI_API_KEY（Gemini API用）
- *   2. 実行: npx tsx scripts/backfill-embeddings.ts
+ *   2. 実行: pnpm exec tsx scripts/backfill-embeddings.ts
+ *   3. 入力仕様の変更後に全件再生成する場合:
+ *      pnpm exec tsx scripts/backfill-embeddings.ts --force
  *
  * 対象:
- *   - embedding IS NULL のポッドキャスト
- *   - 処理済みのものはスキップ（冪等性）
+ *   - 通常時: embedding IS NULL のポッドキャスト
+ *   - --force指定時: embeddingの有無に関わらず全ポッドキャスト
  */
 
 import { createClient } from "@supabase/supabase-js"
@@ -20,6 +22,7 @@ import { buildEmbeddingInput, generateEmbeddings } from "../lib/gemini/generate-
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+const forceRegenerate = process.argv.includes("--force")
 
 if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
   console.error("❌ 環境変数が不足しています:")
@@ -37,16 +40,21 @@ if (!process.env.GEMINI_API_KEY) {
 const BATCH_SIZE = 50
 
 async function main() {
-  console.log("🚀 embedding一括付与スクリプト開始\n")
+  console.log(`🚀 embedding一括付与スクリプト開始${forceRegenerate ? "（全件再生成）" : ""}\n`)
 
   const supabase = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!)
 
   console.log("📋 対象ポッドキャストを取得中...")
-  const { data: podcasts, error: fetchError } = await supabase
+  let query = supabase
     .from("podcasts")
     .select("id, title, description")
-    .is("embedding", null)
     .order("created_at", { ascending: true })
+
+  if (!forceRegenerate) {
+    query = query.is("embedding", null)
+  }
+
+  const { data: podcasts, error: fetchError } = await query
 
   if (fetchError) {
     console.error("❌ ポッドキャスト取得エラー:", fetchError)
@@ -62,17 +70,27 @@ async function main() {
 
   let successCount = 0
   let errorCount = 0
+  let skippedCount = 0
 
   for (let offset = 0; offset < podcasts.length; offset += BATCH_SIZE) {
     const batch = podcasts.slice(offset, offset + BATCH_SIZE)
     console.log(`[${offset + 1}〜${offset + batch.length}/${podcasts.length}] embedding生成中...`)
 
     try {
-      const embeddings = await generateEmbeddings(
-        batch.map((podcast) => buildEmbeddingInput(podcast.title, podcast.description))
-      )
+      const targets = batch
+        .map((podcast) => ({
+          podcast,
+          input: buildEmbeddingInput(podcast.title, podcast.description),
+        }))
+        .filter((target) => target.input)
 
-      for (const [i, podcast] of batch.entries()) {
+      skippedCount += batch.length - targets.length
+      if (targets.length === 0) continue
+
+      const embeddings = await generateEmbeddings(targets.map((target) => target.input))
+
+      for (const [i, target] of targets.entries()) {
+        const { podcast } = target
         const { error: updateError } = await supabase
           .from("podcasts")
           .update({ embedding: embeddings[i] })
@@ -96,6 +114,7 @@ async function main() {
   console.log("=".repeat(60))
   console.log(`✅ 成功: ${successCount}件`)
   console.log(`❌ 失敗: ${errorCount}件`)
+  console.log(`⏭️ スキップ（タイトル・説明なし）: ${skippedCount}件`)
   console.log(`📋 合計: ${podcasts.length}件\n`)
 
   console.log("🎉 スクリプト完了")

--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -39,29 +39,38 @@ if (!process.env.GEMINI_API_KEY) {
 // 1回のembedding API呼び出しで処理する件数
 const BATCH_SIZE = 50
 
+// Supabaseの最大返却件数に依存せず全件取得するためのページサイズ
+const FETCH_PAGE_SIZE = 1000
+
 async function main() {
   console.log(`🚀 embedding一括付与スクリプト開始${forceRegenerate ? "（全件再生成）" : ""}\n`)
 
   const supabase = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!)
 
   console.log("📋 対象ポッドキャストを取得中...")
-  let query = supabase
-    .from("podcasts")
-    .select("id, title, description")
-    .order("created_at", { ascending: true })
+  const podcasts: Array<{ id: string; title: string | null; description: string | null }> = []
 
-  if (!forceRegenerate) {
-    query = query.is("embedding", null)
+  for (let from = 0; ; from += FETCH_PAGE_SIZE) {
+    let query = supabase.from("podcasts").select("id, title, description")
+    if (!forceRegenerate) {
+      query = query.is("embedding", null)
+    }
+
+    const { data: page, error: fetchError } = await query
+      .order("created_at", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, from + FETCH_PAGE_SIZE - 1)
+
+    if (fetchError) {
+      console.error("❌ ポッドキャスト取得エラー:", fetchError)
+      process.exit(1)
+    }
+
+    podcasts.push(...(page ?? []))
+    if (!page || page.length < FETCH_PAGE_SIZE) break
   }
 
-  const { data: podcasts, error: fetchError } = await query
-
-  if (fetchError) {
-    console.error("❌ ポッドキャスト取得エラー:", fetchError)
-    process.exit(1)
-  }
-
-  if (!podcasts || podcasts.length === 0) {
+  if (podcasts.length === 0) {
     console.log("✅ 対象ポッドキャストなし（すべて処理済み）")
     process.exit(0)
   }


### PR DESCRIPTION
## 概要

- Gemini Embedding 2の推奨形式に合わせ、`sentence similarity`用途のprefixを入力へ追加
- URL除去後の説明文を先頭500文字に制限し、後半の宣伝・リンク集によるノイズを削減
- タイトル・説明がないデータはembedding生成をスキップ
- 興味プロファイルを視聴中・視聴済みのコンテンツだけから生成
- 既存embeddingを全件再生成する`--force`オプションを追加

## 背景

従来はURLだけを除いた説明文全文をembeddingへ渡し、未視聴を含む全ポッドキャストの平均を興味プロファイルとしていた。そのため、説明後半の定型文や保存しただけのコンテンツがレコメンドの意味表現を薄めていた。

## 影響・適用手順

デプロイ時に`017_exclude_unwatched_from_recommendations.sql`を適用し、入力形式を揃えるため既存データを次のコマンドで再生成する。

```bash
pnpm exec tsx scripts/backfill-embeddings.ts --force
```

## 検証

- `pnpm run test`（20ファイル、233テスト成功）
- `pnpm run check`

## 関連

「興味なし」フィードバックは #336 で別途対応する。